### PR TITLE
Explain what caused a given node to be built

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ LUA_SOURCES = \
 LIBTUNDRA_SOURCES = \
 	BinaryWriter.cpp BuildQueue.cpp Common.cpp DagGenerator.cpp \
 	Driver.cpp FileInfo.cpp Hash.cpp HashTable.cpp \
-	IncludeScanner.cpp JsonParse.cpp MemAllocHeap.cpp \
+	IncludeScanner.cpp JsonParse.cpp JsonWriter.cpp MemAllocHeap.cpp \
 	MemAllocLinear.cpp MemoryMappedFile.cpp PathUtil.cpp Profiler.cpp \
 	ScanCache.cpp Scanner.cpp SignalHandler.cpp StatCache.cpp \
 	TargetSelect.cpp Thread.cpp \

--- a/src/BuildQueue.cpp
+++ b/src/BuildQueue.cpp
@@ -391,6 +391,9 @@ namespace t2
     // will mean hashing twice, but that would probably still be faster on average).
     HashSetLogComponents(&sighash, component_log);
 
+    node->m_FirstInputSignatureComponentIndex = component_log->components.m_Size;
+
+
     // Start with command line action. If that changes, we'll definitely have to rebuild.
     HashSetNextComponent(&sighash, HashComponent::kGeneric, "Action", true);
     HashAddString(&sighash, node_data->m_Action);
@@ -451,8 +454,7 @@ namespace t2
 
     HashFinalize(&sighash, &node->m_InputSignature);
 
-    node->m_TotalInputSignatureComponents = sighash.m_ComponentCount;
-    node->m_FirstInputSignatureComponentIndex = sighash.m_LastComponentIndex + 1 - sighash.m_ComponentCount;
+    node->m_TotalInputSignatureComponents = component_log->components.m_Size - node->m_FirstInputSignatureComponentIndex;
       
     if (component_log)
       MutexUnlock(&component_log->mutex);

--- a/src/BuildQueue.cpp
+++ b/src/BuildQueue.cpp
@@ -366,7 +366,7 @@ namespace t2
     HashComponentLog* component_log = config.m_InputSignatureHashLog;
 
     const NodeData* node_data = node->m_MmapData;
-    const uint64_t node_index = (node_data - queue->m_Config.m_NodeData);
+    const uint64_t node_index = node_data->m_OriginalIndex;
 
     HashState sighash;
     FILE* debug_log = (FILE*) queue->m_Config.m_FileSigningLog;

--- a/src/BuildQueue.cpp
+++ b/src/BuildQueue.cpp
@@ -267,12 +267,12 @@ namespace t2
     JsonWriteKeyName(msg, "annotation");
     JsonWriteValueString(msg, node->m_MmapData->m_Annotation.Get());
 
-    if (prev_state->m_InputSignatureComponents.GetCount() != node->m_TotalInputSignatureComponents)
+    if (prev_state->m_InputSignatureComponents.GetCount() != node->m_ComponentLogRange.m_Count)
     {
       JsonWriteKeyName(msg, "oldKeyCount");
       JsonWriteValueInteger(msg, prev_state->m_InputSignatureComponents.GetCount());
       JsonWriteKeyName(msg, "newKeyCount");
-      JsonWriteValueInteger(msg, node->m_TotalInputSignatureComponents);
+      JsonWriteValueInteger(msg, node->m_ComponentLogRange.m_Count);
       goto endObjectAndLog;
     }
     
@@ -281,9 +281,9 @@ namespace t2
     JsonWriteKeyName(msg, "changes");
     JsonWriteStartArray(msg);
 
-    for (int i = 0; i < node->m_TotalInputSignatureComponents; ++i)
+    for (int i = 0; i < node->m_ComponentLogRange.m_Count; ++i)
     {
-      HashComponent& component = hashComponentLog->components[node->m_FirstInputSignatureComponentIndex + i];
+      HashComponent& component = hashComponentLog->components[node->m_ComponentLogRange.m_Index + i];
 
       const char* key = &hashComponentLog->strings[component.m_Key];
       const char* prevKey = prev_state->m_InputSignatureComponents[i].m_Key.Get();
@@ -391,7 +391,7 @@ namespace t2
     // will mean hashing twice, but that would probably still be faster on average).
     HashSetLogComponents(&sighash, component_log);
 
-    node->m_FirstInputSignatureComponentIndex = component_log->components.m_Size;
+    node->m_ComponentLogRange.m_Index = component_log->components.m_Size;
 
 
     // Start with command line action. If that changes, we'll definitely have to rebuild.
@@ -454,7 +454,7 @@ namespace t2
 
     HashFinalize(&sighash, &node->m_InputSignature);
 
-    node->m_TotalInputSignatureComponents = component_log->components.m_Size - node->m_FirstInputSignatureComponentIndex;
+    node->m_ComponentLogRange.m_Count = component_log->components.m_Size - node->m_ComponentLogRange.m_Index;
       
     if (component_log)
       MutexUnlock(&component_log->mutex);

--- a/src/BuildQueue.cpp
+++ b/src/BuildQueue.cpp
@@ -258,7 +258,7 @@ namespace t2
     return MakeDirectoriesRecursive(stat_cache, path);
   }
 
-  static void ReportInputSignatureChangeCause(JsonWriter* msg, NodeState* node, const NodeStateData* prev_state, HashComponentLog* hashComponentLog)
+  static void ReportInputSignatureChangeCause(JsonWriter* msg, NodeState* node, const uint64_t node_index, const NodeStateData* prev_state, HashComponentLog* hashComponentLog)
   {
     JsonWriteReset(msg);
     JsonWriteStartObject(msg);
@@ -266,6 +266,8 @@ namespace t2
     JsonWriteValueString(msg, "inputSignatureChanged");
     JsonWriteKeyName(msg, "annotation");
     JsonWriteValueString(msg, node->m_MmapData->m_Annotation.Get());
+    JsonWriteKeyName(msg, "index");
+    JsonWriteValueInteger(msg, node_index);
 
     if (prev_state->m_InputSignatureComponents.GetCount() != node->m_ComponentLogRange.m_Count)
     {
@@ -364,6 +366,7 @@ namespace t2
     HashComponentLog* component_log = config.m_InputSignatureHashLog;
 
     const NodeData* node_data = node->m_MmapData;
+    const uint64_t node_index = (node_data - queue->m_Config.m_NodeData);
 
     HashState sighash;
     FILE* debug_log = (FILE*) queue->m_Config.m_FileSigningLog;
@@ -469,8 +472,10 @@ namespace t2
       JsonWriteStartObject(msg);
       JsonWriteKeyName(msg, "msg");
       JsonWriteValueString(msg, "newNode");
-      JsonWriteKeyName(msg, "node");
+      JsonWriteKeyName(msg, "annotation");
       JsonWriteValueString(msg, node_data->m_Annotation);
+      JsonWriteKeyName(msg, "index");
+      JsonWriteValueInteger(msg, node_index);
       JsonWriteEndObject(msg);
       LogStructured(msg);
 
@@ -488,7 +493,7 @@ namespace t2
       Log(kSpam, "T=%d: building %s - input signature changed. was:%s now:%s", thread_state->m_ThreadIndex, node_data->m_Annotation.Get(), oldDigest, newDigest);
 
       if (component_log != nullptr)
-        ReportInputSignatureChangeCause(&thread_state->m_StructuredMsg, node, prev_state, component_log);
+        ReportInputSignatureChangeCause(&thread_state->m_StructuredMsg, node, node_index, prev_state, component_log);
 
       next_state = BuildProgress::kRunAction;
     }

--- a/src/BuildQueue.hpp
+++ b/src/BuildQueue.hpp
@@ -7,6 +7,7 @@
 #include "Thread.hpp"
 #include "MemAllocLinear.hpp"
 #include "MemAllocHeap.hpp"
+#include "JsonWriter.hpp"
 
 namespace t2
 {
@@ -61,6 +62,7 @@ namespace t2
     MemAllocLinear    m_ScratchAlloc;
     int               m_ThreadIndex;
     BuildQueue*       m_Queue;
+    JsonWriter        m_StructuredMsg;
   };
 
   struct BuildQueue

--- a/src/BuildQueue.hpp
+++ b/src/BuildQueue.hpp
@@ -16,6 +16,7 @@ namespace t2
   struct ScanCache;
   struct StatCache;
   struct DigestCache;
+  struct HashComponentLog;
 
   enum
   {
@@ -49,6 +50,7 @@ namespace t2
     void*           m_FileSigningLog;
     Mutex*          m_FileSigningLogMutex;
     int32_t         m_MaxExpensiveCount;
+    HashComponentLog* m_InputSignatureHashLog;
   };
 
   struct BuildQueue;

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -254,6 +254,7 @@ void LogStructured(LogLevel level, const char* msg, const char* payloadFmt, ...)
   }
 
   fputs("}\n", s_StructuredLog);
+  fflush(s_StructuredLog);
 
   MutexUnlock(&s_StructuredLogMutex);
 }

--- a/src/Common.hpp
+++ b/src/Common.hpp
@@ -71,6 +71,8 @@ void SetLogFlags(int log_level);
 
 void Log(LogLevel level, const char* fmt, ...);
 
+void SetStructuredLogPath(const char* path);
+void LogStructured(LogLevel level, const char* msg, const char* payloadFmt, ...);
 
 //-----------------------------------------------------------------------------
 // String hashing

--- a/src/Common.hpp
+++ b/src/Common.hpp
@@ -71,8 +71,10 @@ void SetLogFlags(int log_level);
 
 void Log(LogLevel level, const char* fmt, ...);
 
+struct JsonWriter;
+
 void SetStructuredLogPath(const char* path);
-void LogStructured(LogLevel level, const char* msg, const char* payloadFmt, ...);
+void LogStructured(JsonWriter* writer);
 
 //-----------------------------------------------------------------------------
 // String hashing

--- a/src/DagData.hpp
+++ b/src/DagData.hpp
@@ -130,7 +130,7 @@ struct PassData
 
 struct DagData
 {
-  static const uint32_t         MagicNumber   = 0x1589011f ^ kTundraHashMagic;
+  static const uint32_t         MagicNumber   = 0x1589012f ^ kTundraHashMagic;
 
   uint32_t                      m_MagicNumber;
 
@@ -174,6 +174,7 @@ struct DagData
   FrozenString                  m_DigestCacheFileName;
   FrozenString                  m_DigestCacheFileNameTmp;
   FrozenString                  m_BuildTitle;
+  FrozenString                  m_StructuredLogPath;
   
   uint32_t                      m_ForceDagRebuild;
   uint32_t                      m_MagicNumberEnd;

--- a/src/DagData.hpp
+++ b/src/DagData.hpp
@@ -121,6 +121,7 @@ struct NodeData
   FrozenArray<EnvVarData>         m_EnvVars;
   FrozenPtr<ScannerData>          m_Scanner;
   uint32_t                        m_Flags;
+  uint32_t                        m_OriginalIndex;
 };
 
 struct PassData
@@ -130,7 +131,7 @@ struct PassData
 
 struct DagData
 {
-  static const uint32_t         MagicNumber   = 0x1589012f ^ kTundraHashMagic;
+  static const uint32_t         MagicNumber   = 0x1589013f ^ kTundraHashMagic;
 
   uint32_t                      m_MagicNumber;
 

--- a/src/DagGenerator.cpp
+++ b/src/DagGenerator.cpp
@@ -231,6 +231,12 @@ static bool WriteNodes(
     }
   }
 
+  uint32_t* reverse_remap = (uint32_t*)HeapAllocate(heap, node_count * sizeof(uint32_t));
+  for (uint32_t i = 0; i < node_count; ++i)
+  {
+    reverse_remap[remap_table[i]] = i;
+  }
+
   for (size_t ni = 0; ni < node_count; ++ni)
   {
     const int32_t i = order[ni].m_Node;
@@ -362,6 +368,7 @@ static bool WriteNodes(
       flags |= NodeData::kFlagIsWriteTextFileAction;
     
     BinarySegmentWriteUint32(node_data_seg, flags);
+    BinarySegmentWriteUint32(node_data_seg, reverse_remap[ni]);
   }
 
   for (size_t i = 0; i < node_count; ++i)
@@ -369,6 +376,7 @@ static bool WriteNodes(
     BufferDestroy(&links[i].m_Links, heap);
   }
 
+  HeapFree(heap, reverse_remap);
   HeapFree(heap, links);
 
   return true;

--- a/src/DagGenerator.cpp
+++ b/src/DagGenerator.cpp
@@ -906,6 +906,8 @@ static bool CompileDag(const JsonObjectValue* root, BinaryWriter* writer, MemAll
   WriteStringPtr(main_seg, str_seg, FindStringValue(root, "DigestCacheFileNameTmp", ".tundra2.digestcache.tmp"));
   
   WriteStringPtr(main_seg, str_seg, FindStringValue(root, "BuildTitle", "Tundra"));
+  WriteStringPtr(main_seg, str_seg, FindStringValue(root, "StructuredLogPath"));
+
   BinarySegmentWriteInt32(main_seg, (int) FindIntValue(root, "ForceDagRebuild", 0));
 
   HashTableDestroy(&shared_strings);
@@ -936,8 +938,6 @@ static bool CreateDagFromJsonData(char* json_memory, const char* dag_fn)
   {
     if (const JsonObjectValue* obj = value->AsObject())
     {
-      SetStructuredLogPath(FindStringValue(obj, "StructuredLogPath"));
-
       if (obj->m_Count == 0)
       {
         Log(kInfo, "Nothing to do");

--- a/src/DagGenerator.cpp
+++ b/src/DagGenerator.cpp
@@ -936,6 +936,8 @@ static bool CreateDagFromJsonData(char* json_memory, const char* dag_fn)
   {
     if (const JsonObjectValue* obj = value->AsObject())
     {
+      SetStructuredLogPath(FindStringValue(obj, "StructuredLogPath"));
+
       if (obj->m_Count == 0)
       {
         Log(kInfo, "Nothing to do");

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -176,6 +176,30 @@ void DriverShowTargets(Driver* self)
   }
 }
 
+void DriverReportStartup(Driver* self, const char** targets, int target_count)
+{
+  JsonWriter msg;
+  JsonWriteInit(&msg, &self->m_Heap);
+  JsonWriteStartObject(&msg);
+
+  JsonWriteKeyName(&msg, "msg");
+  JsonWriteValueString(&msg, "init");
+
+  JsonWriteKeyName(&msg, "dagFile");
+  JsonWriteValueString(&msg, self->m_Options.m_DAGFileName);
+
+  JsonWriteKeyName(&msg, "targets");
+  JsonWriteStartArray(&msg);
+  for (int i = 0; i < target_count; ++i)
+    JsonWriteValueString(&msg, targets[i]);
+  JsonWriteEndArray(&msg);
+
+  JsonWriteEndObject(&msg);
+
+  LogStructured(&msg);
+  JsonWriteDestroy(&msg);
+}
+
 bool DriverInitData(Driver* self)
 {
   ProfilerScope prof_scope("Tundra InitData", 0);

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -992,13 +992,13 @@ bool DriverSaveBuildState(Driver* self)
     BinarySegmentWriteUint32(state_seg, (uint32_t)now/millisecondsInADay);
   };
 
-  auto save_node_signature_components_live = [=](const int32_t firstSignatureComponent, const int32_t signatureComponentsCount) -> void
+  auto save_node_signature_components_live = [=](const HashComponentLogRange& range) -> void
   {
-    BinarySegmentWriteInt32(state_seg, signatureComponentsCount);
+    BinarySegmentWriteInt32(state_seg, range.m_Count);
     BinarySegmentWritePointer(state_seg, BinarySegmentPosition(array_seg));
-    for (int32_t i = 0; i < signatureComponentsCount; ++i)
+    for (int32_t i = 0; i < range.m_Count; ++i)
     {
-      HashComponent& component = self->m_InputSignatureComponents.components[firstSignatureComponent + i];
+      HashComponent& component = self->m_InputSignatureComponents.components[range.m_Index + i];
       BinarySegmentWritePointer(array_seg, BinarySegmentPosition(string_seg));
       BinarySegmentWriteStringData(string_seg, &self->m_InputSignatureComponents.strings[component.m_Key]);
       BinarySegmentWritePointer(array_seg, BinarySegmentPosition(string_seg));
@@ -1072,7 +1072,7 @@ bool DriverSaveBuildState(Driver* self)
     else
     {
       save_node_state(elem->m_BuildResult, &elem->m_InputSignature, src_elem, guid);
-      save_node_signature_components_live(elem->m_FirstInputSignatureComponentIndex, elem->m_TotalInputSignatureComponents);
+      save_node_signature_components_live(elem->m_ComponentLogRange);
       ++entry_count;
       ++g_Stats.m_StateSaveNew;
     }

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -183,6 +183,8 @@ bool DriverInitData(Driver* self)
   if (!DriverPrepareDag(self, s_DagFileName))
     return false;
 
+  SetStructuredLogPath(self->m_DagData->m_StructuredLogPath);
+
   DigestCacheInit(&self->m_DigestCache, MB(128), self->m_DagData->m_DigestCacheFileName);
 
   LoadFrozenData<StateData>(self->m_DagData->m_StateFileName, &self->m_StateFile, &self->m_StateData);

--- a/src/Driver.hpp
+++ b/src/Driver.hpp
@@ -101,6 +101,8 @@ void DriverShowHelp(Driver* self);
 
 void DriverShowTargets(Driver* self);
 
+void DriverReportStartup(Driver* self, const char** targets, int target_count);
+
 void DriverRemoveStaleOutputs(Driver* self);
 
 void DriverCleanOutputs(Driver* self);

--- a/src/Driver.hpp
+++ b/src/Driver.hpp
@@ -78,6 +78,8 @@ struct Driver
   // Space for dynamic DAG node state
   Buffer<NodeState> m_Nodes;
 
+  HashComponentLog  m_InputSignatureComponents;
+
   MemAllocLinear    m_ScanCacheAllocator;
   ScanCache         m_ScanCache;
 

--- a/src/FileSign.cpp
+++ b/src/FileSign.cpp
@@ -11,6 +11,10 @@ namespace t2
 
 static void ComputeFileSignatureSha1(HashState* state, StatCache* stat_cache, DigestCache* digest_cache, const char* filename, uint32_t fn_hash)
 {
+  char* hashComponentName = (char*)alloca(strlen(filename) + 20);
+  sprintf(hashComponentName, "%s SHA1", filename);
+  HashSetNextComponent(state, hashComponentName, false);
+
   FileInfo file_info = StatCacheStat(stat_cache, filename, fn_hash);
 
   if (!file_info.Exists())
@@ -28,6 +32,7 @@ static void ComputeFileSignatureSha1(HashState* state, StatCache* stat_cache, Di
     FILE* f = fopen(filename, "rb");
     if (!f)
     {
+      HashSetNextComponent(state, hashComponentName, true);
       HashAddString(state, "<missing>");
       return;
     }
@@ -55,6 +60,10 @@ static void ComputeFileSignatureSha1(HashState* state, StatCache* stat_cache, Di
 
 static bool ComputeFileSignatureTimestamp(HashState* out, StatCache* stat_cache, const char* filename, uint32_t hash)
 {
+  char* hashComponentName = (char*)alloca(strlen(filename) + 20);
+  sprintf(hashComponentName, "%s Timestamp", filename);
+  HashSetNextComponent(out, hashComponentName, false);
+
   FileInfo info = StatCacheStat(stat_cache, filename, hash);
   if (info.Exists())
     HashAddInteger(out, info.m_Timestamp);

--- a/src/FileSign.cpp
+++ b/src/FileSign.cpp
@@ -11,9 +11,7 @@ namespace t2
 
 static void ComputeFileSignatureSha1(HashState* state, StatCache* stat_cache, DigestCache* digest_cache, const char* filename, uint32_t fn_hash)
 {
-  char* hashComponentName = (char*)alloca(strlen(filename) + 20);
-  sprintf(hashComponentName, "%s SHA1", filename);
-  HashSetNextComponent(state, hashComponentName, false);
+  HashSetNextComponent(state, HashComponent::kFileSHA1, filename, false);
 
   FileInfo file_info = StatCacheStat(stat_cache, filename, fn_hash);
 
@@ -32,7 +30,7 @@ static void ComputeFileSignatureSha1(HashState* state, StatCache* stat_cache, Di
     FILE* f = fopen(filename, "rb");
     if (!f)
     {
-      HashSetNextComponent(state, hashComponentName, true);
+      HashSetNextComponent(state, HashComponent::kFileSHA1, filename, true);
       HashAddString(state, "<missing>");
       return;
     }
@@ -60,9 +58,7 @@ static void ComputeFileSignatureSha1(HashState* state, StatCache* stat_cache, Di
 
 static bool ComputeFileSignatureTimestamp(HashState* out, StatCache* stat_cache, const char* filename, uint32_t hash)
 {
-  char* hashComponentName = (char*)alloca(strlen(filename) + 20);
-  sprintf(hashComponentName, "%s Timestamp", filename);
-  HashSetNextComponent(out, hashComponentName, false);
+  HashSetNextComponent(out, HashComponent::kFileTimestamp, filename, false);
 
   FileInfo info = StatCacheStat(stat_cache, filename, hash);
   if (info.Exists())

--- a/src/FileSign.hpp
+++ b/src/FileSign.hpp
@@ -20,7 +20,8 @@ void ComputeFileSignature(
   const char*         filename,
   uint32_t            fn_hash,
   const uint32_t      sha_extension_hashes[],
-  int                 sha_extension_hash_count);
+  int                 sha_extension_hash_count,
+  HashComponentLog*   component_log);
 
   HashDigest CalculateGlobSignatureFor(const char* path, MemAllocHeap* heap, MemAllocLinear* scratch);
 

--- a/src/Hash.cpp
+++ b/src/Hash.cpp
@@ -79,9 +79,6 @@ void HashUpdate(HashState* self, const void *data_in, size_t size)
 
     BufferAppendOne(&self->m_ComponentLog->components, self->m_ComponentLog->heap, c);
 
-    self->m_ComponentCount++;
-    self->m_LastComponentIndex = self->m_ComponentLog->components.m_Size - 1;
-
     self->m_NextComponentName = nullptr;
   }
 }
@@ -147,8 +144,6 @@ void HashInitDebug(HashState* self, void* fh)
 void HashSetLogComponents(HashState* self, HashComponentLog* componentLog)
 {
   self->m_ComponentLog = componentLog;
-  self->m_ComponentCount = 0;
-  self->m_LastComponentIndex = 0;
 }
 
 void HashSetNextComponent(HashState* self, HashComponent::Kinds kind, const char* name, bool isString)

--- a/src/Hash.cpp
+++ b/src/Hash.cpp
@@ -54,6 +54,7 @@ void HashUpdate(HashState* self, const void *data_in, size_t size)
   {
     // Log this component
     HashComponent c;
+    c.m_Kind = self->m_NextComponentKind;
     c.m_Key = self->m_ComponentLog->strings.m_Size;
     BufferAppend(&self->m_ComponentLog->strings, self->m_ComponentLog->heap, self->m_NextComponentName, strlen(self->m_NextComponentName) + 1);
 
@@ -150,9 +151,10 @@ void HashSetLogComponents(HashState* self, HashComponentLog* componentLog)
   self->m_LastComponentIndex = 0;
 }
 
-void HashSetNextComponent(HashState* self, const char* name, bool isString)
+void HashSetNextComponent(HashState* self, HashComponent::Kinds kind, const char* name, bool isString)
 {
   self->m_NextComponentName = name;
+  self->m_NextComponentKind = kind;
   self->m_NextComponentIsString = isString;
 }
 

--- a/src/Hash.hpp
+++ b/src/Hash.hpp
@@ -161,6 +161,8 @@ struct HashComponent
 
 struct HashComponentLog
 {
+  // TODO: Instead of HashComponent storing indices into the strings buffer, it might be nicer to use
+  // BinaryWriter to build this up, where components and strings are BinarySegments. Look into it...
   Buffer<HashComponent> components;
   Buffer<char> strings;
   MemAllocHeap* heap;

--- a/src/Hash.hpp
+++ b/src/Hash.hpp
@@ -178,6 +178,12 @@ struct HashComponentLog
   Mutex mutex;
 };
 
+struct HashComponentLogRange
+{
+  uint32_t m_Index;
+  uint32_t m_Count;
+};
+
 struct ALIGN(16) HashState
 {
   HashStateImpl m_StateImpl;

--- a/src/Hash.hpp
+++ b/src/Hash.hpp
@@ -190,8 +190,6 @@ struct ALIGN(16) HashState
   const char*   m_NextComponentName;
   HashComponent::Kinds m_NextComponentKind;
   bool          m_NextComponentIsString;
-  size_t        m_LastComponentIndex;
-  size_t        m_ComponentCount;
 };
 
 // Initialize hashing state.

--- a/src/Hash.hpp
+++ b/src/Hash.hpp
@@ -155,6 +155,15 @@ struct ALIGN(16) HashStateImpl
 
 struct HashComponent
 {
+  enum Kinds
+  {
+    kGeneric,
+    kFilePath,
+    kFileTimestamp,
+    kFileSHA1
+  };
+
+  Kinds m_Kind;
   uint32_t m_Key;
   uint32_t m_Value;
 };
@@ -179,6 +188,7 @@ struct ALIGN(16) HashState
   
   HashComponentLog* m_ComponentLog;
   const char*   m_NextComponentName;
+  HashComponent::Kinds m_NextComponentKind;
   bool          m_NextComponentIsString;
   size_t        m_LastComponentIndex;
   size_t        m_ComponentCount;
@@ -193,7 +203,7 @@ void HashInitDebug(HashState* h, void* file_handle);
 // Install a log target for hash components, to record the values that the hash was actually calculated from
 void HashSetLogComponents(HashState* h, HashComponentLog* componentLog);
 
-void HashSetNextComponent(HashState* h, const char* name, bool isString);
+void HashSetNextComponent(HashState* h, HashComponent::Kinds kind, const char* name, bool isString);
 
 // Add arbitrary data to be hashed.
 void HashUpdate(HashState* h, const void* data, size_t size);

--- a/src/JsonWriter.cpp
+++ b/src/JsonWriter.cpp
@@ -1,0 +1,104 @@
+#include "JsonWriter.hpp"
+#include <stdio.h>
+
+namespace t2
+{
+
+void JsonWriteInit(JsonWriter* writer, MemAllocHeap* heap)
+{
+    writer->m_Heap = heap;
+    BufferInitWithCapacity(&writer->m_Buffer, heap, 200);
+    JsonWriteReset(writer);
+}
+
+void JsonWriteDestroy(JsonWriter* writer)
+{
+    BufferDestroy(&writer->m_Buffer, writer->m_Heap);
+}
+
+void JsonWriteReset(JsonWriter* writer)
+{
+    BufferClear(&writer->m_Buffer);
+    writer->m_PrependComma = false;
+}
+
+void JsonWriteStartObject(JsonWriter* writer)
+{
+    if (writer->m_PrependComma)
+        BufferAppendOne(&writer->m_Buffer, writer->m_Heap, ',');
+
+    BufferAppendOne(&writer->m_Buffer, writer->m_Heap, '{');
+    writer->m_PrependComma = false;
+}
+
+void JsonWriteEndObject(JsonWriter* writer)
+{
+    BufferAppendOne(&writer->m_Buffer, writer->m_Heap, '}');
+    writer->m_PrependComma = true;
+}
+
+void JsonWriteStartArray(JsonWriter* writer)
+{
+    if (writer->m_PrependComma)
+        BufferAppendOne(&writer->m_Buffer, writer->m_Heap, ',');
+
+    BufferAppendOne(&writer->m_Buffer, writer->m_Heap, '[');
+    writer->m_PrependComma = false;
+}
+
+void JsonWriteEndArray(JsonWriter* writer)
+{
+    BufferAppendOne(&writer->m_Buffer, writer->m_Heap, ']');
+    writer->m_PrependComma = true;
+}
+
+void JsonWriteKeyName(JsonWriter* writer, const char* keyName)
+{
+    JsonWriteValueString(writer, keyName);
+    BufferAppendOne(&writer->m_Buffer, writer->m_Heap, ':');
+    writer->m_PrependComma = false;
+}
+
+void JsonWriteValueString(JsonWriter* writer, const char* value)
+{
+    if (writer->m_PrependComma)
+        BufferAppendOne(&writer->m_Buffer, writer->m_Heap, ',');
+
+    BufferAppendOne(&writer->m_Buffer, writer->m_Heap, '"');
+
+    while (*value != 0)
+    {
+        char ch = *(value++);
+        if (ch == '"')
+        {
+            BufferAppend(&writer->m_Buffer, writer->m_Heap, "\\\"", 2);
+        }
+        else if (ch == '\\')
+        {
+            BufferAppend(&writer->m_Buffer, writer->m_Heap, "\\\\", 2);
+        }
+        else
+        {
+            BufferAppendOne(&writer->m_Buffer, writer->m_Heap, ch);
+        }
+    }
+
+    BufferAppendOne(&writer->m_Buffer, writer->m_Heap, '"');
+
+    writer->m_PrependComma = true;
+}
+
+void JsonWriteValueInteger(JsonWriter* writer, int64_t value)
+{
+    if (writer->m_PrependComma)
+        BufferAppendOne(&writer->m_Buffer, writer->m_Heap, ',');
+
+    char buf[50];
+    snprintf(buf, 50, "%lli", value);
+
+    BufferAppend(&writer->m_Buffer, writer->m_Heap, buf, strlen(buf));
+
+    writer->m_PrependComma = true;
+}
+
+}

--- a/src/JsonWriter.hpp
+++ b/src/JsonWriter.hpp
@@ -1,0 +1,35 @@
+#ifndef JSONWRITER_HPP
+#define JSONWRITER_HPP
+
+#include "Buffer.hpp"
+
+namespace t2
+{
+
+struct JsonWriter
+{
+  MemAllocHeap* m_Heap;
+  Buffer<char> m_Buffer;
+  bool m_PrependComma;
+};
+
+void JsonWriteInit(JsonWriter* writer, MemAllocHeap* heap);
+void JsonWriteDestroy(JsonWriter* writer);
+
+void JsonWriteReset(JsonWriter* writer);
+
+void JsonWriteStartObject(JsonWriter* writer);
+void JsonWriteEndObject(JsonWriter* writer);
+
+void JsonWriteStartArray(JsonWriter* writer);
+void JsonWriteEndArray(JsonWriter* writer);
+
+
+void JsonWriteKeyName(JsonWriter* writer, const char* keyName);
+
+void JsonWriteValueString(JsonWriter* writer, const char* value);
+void JsonWriteValueInteger(JsonWriter* writer, int64_t value);
+
+}
+
+#endif

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -447,6 +447,8 @@ int main(int argc, char* argv[])
     goto leave;
   }
 
+  DriverReportStartup(&driver, (const char**) argv, argc);
+
   //we dont remove stale outputs for now, as buildstate is shared between multiple dags. at some point
   //we should implement deleting artifacts when we drop old nodes from the buildstate
   //DriverRemoveStaleOutputs(&driver);

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -543,6 +543,8 @@ leave:
     }
   }
 
+  SetStructuredLogPath(nullptr);
+
   return build_result == BuildResult::kOk ? 0 : 1;
 
   // Match up nodes to nodes in the build state

--- a/src/NodeState.hpp
+++ b/src/NodeState.hpp
@@ -47,8 +47,7 @@ struct NodeState
   const char**              m_ImplicitDeps;
 
   HashDigest                m_InputSignature;
-  uint32_t                  m_FirstInputSignatureComponentIndex;
-  uint32_t                  m_TotalInputSignatureComponents;
+  HashComponentLogRange     m_ComponentLogRange;
 };
 
 inline bool NodeStateIsCompleted(const NodeState* state)

--- a/src/NodeState.hpp
+++ b/src/NodeState.hpp
@@ -47,6 +47,8 @@ struct NodeState
   const char**              m_ImplicitDeps;
 
   HashDigest                m_InputSignature;
+  uint32_t                  m_FirstInputSignatureComponentIndex;
+  uint32_t                  m_TotalInputSignatureComponents;
 };
 
 inline bool NodeStateIsCompleted(const NodeState* state)

--- a/src/StateData.hpp
+++ b/src/StateData.hpp
@@ -7,6 +7,12 @@
 namespace t2
 {
 
+struct NodeSignatureComponent
+{
+  FrozenString m_Key;
+  FrozenString m_Value;
+};
+
 struct NodeStateData
 {
   int32_t                   m_BuildResult;
@@ -14,6 +20,7 @@ struct NodeStateData
   FrozenArray<FrozenString> m_OutputFiles;
   FrozenArray<FrozenString> m_AuxOutputFiles;
   uint32_t                  m_TimeStampOfLastUseInDays;
+  FrozenArray<NodeSignatureComponent> m_InputSignatureComponents;
 };
 
 struct StateData


### PR DESCRIPTION
A common question we will have when working on builds is "why did thing X get built?" Today tunda will build a node if it is new, or if the hash of its inputs (action, input files, etc) has changed, but just knowing "the hash changed" isn't very helpful when it is a hash of 1000 things.

This PR makes three major changes:

1. It changes the way node GUIDs are computed to use the list of outputs rather than the list of inputs. This means that when a node's inputs are changed, we will still be able to retrieve the BuildState for it, and compare the new inputs to the saved information about previous inputs.

2. It adds a 'hash component log' which records the name/role of each individual component being fed to the hash, and saves it into the buildstate for that node. When the overall hashed input signature of the node changes, we can then compare the individual entries in the log to work out exactly which aspect of the input is different.

3. It adds a 'structured' log file, and reports new and changed nodes through it. We do this instead of just using stdout to make it easier to build other tools on top, as the format ('streamed' JSON, i.e. one JSON object per line) is easy for machines to parse, and we don't have to worry much about human-readability this way.