### PR TITLE
Don't print null diagnostic info, e.g. null command lines

### DIFF
--- a/src/NodeResultPrinting.cpp
+++ b/src/NodeResultPrinting.cpp
@@ -112,8 +112,8 @@ static void EnsureConsoleCanHandleColors()
   DWORD dwMode = 0;
   if (GetConsoleMode(hOut, &dwMode))
   {
-    const int ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004;
-    DWORD newMode = dwMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+    const int ENABLE_VIRTUAL_TERMINAL_PROCESSING_impl = 0x0004;
+    DWORD newMode = dwMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING_impl;
     if (newMode != dwMode)
       SetConsoleMode(hOut, newMode);
   }

--- a/src/NodeResultPrinting.cpp
+++ b/src/NodeResultPrinting.cpp
@@ -158,7 +158,8 @@ static void PrintDiagnosticFormat(const char* title, const char* formatString, .
 
 static void PrintDiagnostic(const char* title, const char* contents)
 {
-    PrintDiagnosticFormat(title, "%s", contents);
+    if (contents != nullptr)
+        PrintDiagnosticFormat(title, "%s", contents);
 }
 
 static void PrintDiagnostic(const char* title, int content)


### PR DESCRIPTION
Before:
```
[13/61  0s] WriteText artifacts/tundra/rsp/9879524075154230798.rsp
##### CommandLine
(null)
[14/61  0s] WriteText artifacts/tundra/rsp/10580704316964389383.rsp
##### CommandLine
(null)
```
after:
```
[13/61  0s] WriteText artifacts/tundra/rsp/9879524075154230798.rsp
[14/61  0s] WriteText artifacts/tundra/rsp/10580704316964389383.rsp
```