### PR TITLE
Explain what caused a given node to be built (v2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ LUA_SOURCES = \
 LIBTUNDRA_SOURCES = \
 	BinaryWriter.cpp BuildQueue.cpp Common.cpp DagGenerator.cpp \
 	Driver.cpp FileInfo.cpp Hash.cpp HashTable.cpp \
-	IncludeScanner.cpp JsonParse.cpp MemAllocHeap.cpp \
+	IncludeScanner.cpp JsonParse.cpp JsonWriter.cpp MemAllocHeap.cpp \
 	MemAllocLinear.cpp MemoryMappedFile.cpp PathUtil.cpp Profiler.cpp \
 	ScanCache.cpp Scanner.cpp SignalHandler.cpp StatCache.cpp \
 	TargetSelect.cpp Thread.cpp \

--- a/src/BuildQueue.cpp
+++ b/src/BuildQueue.cpp
@@ -449,13 +449,14 @@ namespace t2
 
         JsonWriteKeyName(msg, "value");
         JsonWriteStartArray(msg);
-        for (const FrozenFileAndHash& input : node_data->m_InputFiles)
-          JsonWriteValueString(msg, input.m_Filename);
+        HashTableWalk(&implicitDependencies, [=](int32_t index, uint32_t hash, const char* filename, bool visited) {
+          JsonWriteValueString(msg, filename);
+        });
         JsonWriteEndArray(msg);
 
         JsonWriteKeyName(msg, "oldvalue");
         JsonWriteStartArray(msg);
-        for (const NodeInputFileData& input : prev_state->m_InputFiles)
+        for (const NodeInputFileData& input : prev_state->m_ImplicitInputFiles)
           JsonWriteValueString(msg, input.m_Filename);
         JsonWriteEndArray(msg);
 

--- a/src/BuildQueue.cpp
+++ b/src/BuildQueue.cpp
@@ -484,6 +484,9 @@ namespace t2
         JsonWriteKeyName(msg, "annotation");
         JsonWriteValueString(msg, node_data->m_Annotation);
 
+        JsonWriteKeyName(msg, "index");
+        JsonWriteValueInteger(msg, node_data->m_OriginalIndex);
+
         JsonWriteEndObject(msg);
         LogStructured(msg);
       }
@@ -512,6 +515,9 @@ namespace t2
 
         JsonWriteKeyName(msg, "annotation");
         JsonWriteValueString(msg, node_data->m_Annotation);
+
+        JsonWriteKeyName(msg, "index");
+        JsonWriteValueInteger(msg, node_data->m_OriginalIndex);
 
         JsonWriteKeyName(msg, "changes");
         JsonWriteStartArray(msg);

--- a/src/BuildQueue.cpp
+++ b/src/BuildQueue.cpp
@@ -1,4 +1,4 @@
-﻿#include "BuildQueue.hpp"
+#include "BuildQueue.hpp"
 #include "DagData.hpp"
 #include "MemAllocHeap.hpp"
 #include "MemAllocLinear.hpp"
@@ -258,7 +258,61 @@ namespace t2
     return MakeDirectoriesRecursive(stat_cache, path);
   }
 
-  static void ReportInputSignatureChanges(JsonWriter* msg, NodeState* node, const NodeData* node_data, const NodeStateData* prev_state, StatCache* stat_cache, DigestCache* digest_cache, ScanCache* scan_cache, const uint32_t sha_extension_hashes[], int sha_extension_hash_count)
+  static void ReportChangedInputFiles(JsonWriter* msg, const FrozenArray<NodeInputFileData>& files, const char* dependencyType, DigestCache* digest_cache, StatCache* stat_cache, const uint32_t sha_extension_hashes[], uint32_t sha_extension_hash_count)
+  {
+    for (const NodeInputFileData& input : files)
+    {
+      uint32_t filenameHash = Djb2HashPath(input.m_Filename);
+
+      if (ShouldUseSHA1SignatureFor(input.m_Filename, sha_extension_hashes, sha_extension_hash_count))
+      {
+        // The file signature was computed from SHA1 digest, so look in the digest cache to see if we computed a new
+        // hash for it that doesn't match the frozen data
+        if (DigestCacheHasChanged(digest_cache, input.m_Filename, filenameHash))
+        {
+          JsonWriteStartObject(msg);
+
+          JsonWriteKeyName(msg, "key");
+          JsonWriteValueString(msg, "InputFileDigest");
+
+          JsonWriteKeyName(msg, "path");
+          JsonWriteValueString(msg, input.m_Filename);
+
+          JsonWriteKeyName(msg, "dependency");
+          JsonWriteValueString(msg, dependencyType);
+
+          JsonWriteEndObject(msg);
+        }
+      }
+      else
+      {
+        // The file signature was computed from timestamp alone, so we only need to examine the stat cache
+        FileInfo fileInfo = StatCacheStat(stat_cache, input.m_Filename, filenameHash);
+
+        uint64_t timestamp = 0;
+        if (fileInfo.Exists())
+          timestamp = fileInfo.m_Timestamp;
+
+        if (timestamp != input.m_Timestamp)
+        {
+          JsonWriteStartObject(msg);
+
+          JsonWriteKeyName(msg, "key");
+          JsonWriteValueString(msg, "InputFileTimestamp");
+
+          JsonWriteKeyName(msg, "path");
+          JsonWriteValueString(msg, input.m_Filename);
+
+          JsonWriteKeyName(msg, "dependency");
+          JsonWriteValueString(msg, dependencyType);
+
+          JsonWriteEndObject(msg);
+        }
+      }
+    }
+  }
+
+  static void ReportInputSignatureChanges(JsonWriter* msg, NodeState* node, const NodeData* node_data, const NodeStateData* prev_state, StatCache* stat_cache, DigestCache* digest_cache, ScanCache* scan_cache, const uint32_t sha_extension_hashes[], int sha_extension_hash_count, ThreadState* thread_state)
   {
     if (strcmp(node_data->m_Action, prev_state->m_Action) != 0)
     {
@@ -296,7 +350,7 @@ namespace t2
     }
 
     bool explicitInputFilesListChanged = node_data->m_InputFiles.GetCount() != prev_state->m_InputFiles.GetCount();
-    for (uint32_t i = 0; i < node_data->m_InputFiles.GetCount() && !explicitInputFilesListChanged; ++i)
+    for (int32_t i = 0; i < node_data->m_InputFiles.GetCount() && !explicitInputFilesListChanged; ++i)
     {
       const char* filename = node_data->m_InputFiles[i].m_Filename;
       const char* oldFilename = prev_state->m_InputFiles[i].m_Filename;
@@ -322,53 +376,100 @@ namespace t2
         JsonWriteValueString(msg, input.m_Filename);
       JsonWriteEndArray(msg);
 
+      JsonWriteKeyName(msg, "dependency");
+      JsonWriteValueString(msg, "explicit");
+
       JsonWriteEndObject(msg);
+
+      // Don't do any further checking for changes, it's going to be a lot of work figuring out which bits of old state
+      // correspond to which bits of new state, for very little benefit
+      return;
     }
-    else
+
+    ReportChangedInputFiles(msg, prev_state->m_InputFiles, "explicit", digest_cache, stat_cache, sha_extension_hashes, sha_extension_hash_count);
+
+    if (node_data->m_Scanner)
     {
-      for (int32_t i = 0; i < node_data->m_InputFiles.GetCount(); ++i)
+      HashTable<bool, kFlagPathStrings> implicitDependencies;
+      HashTableInit(&implicitDependencies, &thread_state->m_LocalHeap);
+
+      for (const FrozenFileAndHash& input : node_data->m_InputFiles)
       {
-        const FrozenFileAndHash& input = node_data->m_InputFiles[i];
-        if (ShouldUseSHA1SignatureFor(input.m_Filename, sha_extension_hashes, sha_extension_hash_count))
+        // Roll back scratch allocator between scans
+        MemAllocLinearScope alloc_scope(&thread_state->m_ScratchAlloc);
+
+        ScanInput scan_input;
+        scan_input.m_ScannerConfig = node_data->m_Scanner;
+        scan_input.m_ScratchAlloc = &thread_state->m_ScratchAlloc;
+        scan_input.m_ScratchHeap = &thread_state->m_LocalHeap;
+        scan_input.m_FileName = input.m_Filename;
+        scan_input.m_ScanCache = scan_cache;
+
+        ScanOutput scan_output;
+
+        if (ScanImplicitDeps(stat_cache, &scan_input, &scan_output))
         {
-          // The file signature was computed from SHA1 digest, so look in the digest cache to see if we computed a new
-          // hash for it that doesn't match the frozen data
-          if (DigestCacheHasChanged(digest_cache, input.m_Filename, input.m_FilenameHash))
+          for (int i = 0, count = scan_output.m_IncludedFileCount; i < count; ++i)
           {
-            JsonWriteStartObject(msg);
-
-            JsonWriteKeyName(msg, "key");
-            JsonWriteValueString(msg, "InputFileDigest");
-
-            JsonWriteKeyName(msg, "path");
-            JsonWriteValueString(msg, input.m_Filename);
-
-            JsonWriteEndObject(msg);
-          }
-        }
-        else
-        {
-          // The file signature was computed from timestamp alone, so we only need to examine the stat cache
-          FileInfo fileInfo = StatCacheStat(stat_cache, input.m_Filename, input.m_FilenameHash);
-
-          uint64_t timestamp = 0;
-          if (fileInfo.Exists())
-            timestamp = fileInfo.m_Timestamp;
-
-          if (timestamp != prev_state->m_InputFiles[i].m_Timestamp)
-          {
-            JsonWriteStartObject(msg);
-
-            JsonWriteKeyName(msg, "key");
-            JsonWriteValueString(msg, "InputFileTimestamp");
-
-            JsonWriteKeyName(msg, "path");
-            JsonWriteValueString(msg, input.m_Filename);
-
-            JsonWriteEndObject(msg);
+            const FileAndHash& path = scan_output.m_IncludedFiles[i];
+            if (HashTableLookup(&implicitDependencies, path.m_FilenameHash, path.m_Filename) == nullptr)
+              HashTableInsert(&implicitDependencies, path.m_FilenameHash, path.m_Filename, false);
           }
         }
       }
+
+      bool implicitFilesListChanged = implicitDependencies.m_RecordCount != prev_state->m_ImplicitInputFiles.GetCount();
+      if (!implicitFilesListChanged)
+      {
+        for (const NodeInputFileData& implicitInput : prev_state->m_ImplicitInputFiles)
+        {
+          bool* visited = HashTableLookup(&implicitDependencies, Djb2HashPath(implicitInput.m_Filename), implicitInput.m_Filename);
+          if (!visited)
+          {
+            implicitFilesListChanged = true;
+            break;
+          }
+
+          *visited = true;
+        }
+
+        HashTableWalk(&implicitDependencies, [&](int32_t index, uint32_t hash, const char* filename, bool visited)
+        {
+          if (!visited)
+            implicitFilesListChanged = true;
+        });
+      }
+
+      if (implicitFilesListChanged)
+      {
+        JsonWriteStartObject(msg);
+
+        JsonWriteKeyName(msg, "key");
+        JsonWriteValueString(msg, "InputFileList");
+
+        JsonWriteKeyName(msg, "value");
+        JsonWriteStartArray(msg);
+        for (const FrozenFileAndHash& input : node_data->m_InputFiles)
+          JsonWriteValueString(msg, input.m_Filename);
+        JsonWriteEndArray(msg);
+
+        JsonWriteKeyName(msg, "oldvalue");
+        JsonWriteStartArray(msg);
+        for (const NodeInputFileData& input : prev_state->m_InputFiles)
+          JsonWriteValueString(msg, input.m_Filename);
+        JsonWriteEndArray(msg);
+
+        JsonWriteKeyName(msg, "dependency");
+        JsonWriteValueString(msg, "implicit");
+
+        JsonWriteEndObject(msg);
+      }
+
+      HashTableDestroy(&implicitDependencies);
+      if (implicitFilesListChanged)
+        return;
+
+      ReportChangedInputFiles(msg, prev_state->m_ImplicitInputFiles, "implicit", digest_cache, stat_cache, sha_extension_hashes, sha_extension_hash_count);
     }
   }
 
@@ -522,7 +623,7 @@ namespace t2
         JsonWriteKeyName(msg, "changes");
         JsonWriteStartArray(msg);
 
-        ReportInputSignatureChanges(msg, node, node_data, prev_state, stat_cache, digest_cache, queue->m_Config.m_ScanCache, config.m_ShaDigestExtensions, config.m_ShaDigestExtensionCount);
+        ReportInputSignatureChanges(msg, node, node_data, prev_state, stat_cache, digest_cache, queue->m_Config.m_ScanCache, config.m_ShaDigestExtensions, config.m_ShaDigestExtensionCount, thread_state);
 
         JsonWriteEndArray(msg);
         JsonWriteEndObject(msg);

--- a/src/BuildQueue.hpp
+++ b/src/BuildQueue.hpp
@@ -60,7 +60,6 @@ namespace t2
     MemAllocLinear    m_ScratchAlloc;
     int               m_ThreadIndex;
     BuildQueue*       m_Queue;
-    JsonWriter        m_StructuredMsg;
   };
 
   struct BuildQueue

--- a/src/BuildQueue.hpp
+++ b/src/BuildQueue.hpp
@@ -7,6 +7,7 @@
 #include "Thread.hpp"
 #include "MemAllocLinear.hpp"
 #include "MemAllocHeap.hpp"
+#include "JsonWriter.hpp"
 
 namespace t2
 {
@@ -59,6 +60,7 @@ namespace t2
     MemAllocLinear    m_ScratchAlloc;
     int               m_ThreadIndex;
     BuildQueue*       m_Queue;
+    JsonWriter        m_StructuredMsg;
   };
 
   struct BuildQueue

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -222,6 +222,11 @@ void SetStructuredLogFileName(const char* path)
   }
 }
 
+bool IsStructuredLogActive()
+{
+  return s_StructuredLog != nullptr;
+}
+
 void LogStructured(JsonWriter* writer)
 {
   if (s_StructuredLog == nullptr)

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -234,7 +234,7 @@ void LogStructured(JsonWriter* writer)
 
   MutexLock(&s_StructuredLogMutex);
 
-  fwrite(writer->m_Buffer.m_Storage, 1, writer->m_Buffer.m_Size, s_StructuredLog);
+  JsonWriteToFile(writer, s_StructuredLog);
   fputc('\n', s_StructuredLog);
 
   MutexUnlock(&s_StructuredLogMutex);

--- a/src/Common.hpp
+++ b/src/Common.hpp
@@ -74,7 +74,7 @@ void Log(LogLevel level, const char* fmt, ...);
 struct JsonWriter;
 
 void SetStructuredLogFileName(const char* path);
-
+bool IsStructuredLogActive();
 void LogStructured(JsonWriter* writer);
 
 //-----------------------------------------------------------------------------

--- a/src/Common.hpp
+++ b/src/Common.hpp
@@ -71,6 +71,11 @@ void SetLogFlags(int log_level);
 
 void Log(LogLevel level, const char* fmt, ...);
 
+struct JsonWriter;
+
+void SetStructuredLogFileName(const char* path);
+
+void LogStructured(JsonWriter* writer);
 
 //-----------------------------------------------------------------------------
 // String hashing

--- a/src/DagData.hpp
+++ b/src/DagData.hpp
@@ -131,7 +131,7 @@ struct PassData
 
 struct DagData
 {
-  static const uint32_t         MagicNumber   = 0x1589012f ^ kTundraHashMagic;
+  static const uint32_t         MagicNumber   = 0x1589013f ^ kTundraHashMagic;
 
   uint32_t                      m_MagicNumber;
 

--- a/src/DagData.hpp
+++ b/src/DagData.hpp
@@ -121,6 +121,7 @@ struct NodeData
   FrozenArray<EnvVarData>         m_EnvVars;
   FrozenPtr<ScannerData>          m_Scanner;
   uint32_t                        m_Flags;
+  uint32_t                        m_OriginalIndex;
 };
 
 struct PassData

--- a/src/DagData.hpp
+++ b/src/DagData.hpp
@@ -130,7 +130,7 @@ struct PassData
 
 struct DagData
 {
-  static const uint32_t         MagicNumber   = 0x1589011f ^ kTundraHashMagic;
+  static const uint32_t         MagicNumber   = 0x1589012f ^ kTundraHashMagic;
 
   uint32_t                      m_MagicNumber;
 
@@ -174,6 +174,7 @@ struct DagData
   FrozenString                  m_DigestCacheFileName;
   FrozenString                  m_DigestCacheFileNameTmp;
   FrozenString                  m_BuildTitle;
+  FrozenString                  m_StructuredLogFileName;
   
   uint32_t                      m_ForceDagRebuild;
   uint32_t                      m_MagicNumberEnd;

--- a/src/DagGenerator.cpp
+++ b/src/DagGenerator.cpp
@@ -231,6 +231,12 @@ static bool WriteNodes(
     }
   }
 
+  uint32_t* reverse_remap = (uint32_t*)HeapAllocate(heap, node_count * sizeof(uint32_t));
+  for (uint32_t i = 0; i < node_count; ++i)
+  {
+    reverse_remap[remap_table[i]] = i;
+  }
+
   for (size_t ni = 0; ni < node_count; ++ni)
   {
     const int32_t i = order[ni].m_Node;
@@ -362,6 +368,7 @@ static bool WriteNodes(
       flags |= NodeData::kFlagIsWriteTextFileAction;
     
     BinarySegmentWriteUint32(node_data_seg, flags);
+    BinarySegmentWriteUint32(node_data_seg, reverse_remap[ni]);
   }
 
   for (size_t i = 0; i < node_count; ++i)
@@ -369,6 +376,7 @@ static bool WriteNodes(
     BufferDestroy(&links[i].m_Links, heap);
   }
 
+  HeapFree(heap, reverse_remap);
   HeapFree(heap, links);
 
   return true;

--- a/src/DagGenerator.cpp
+++ b/src/DagGenerator.cpp
@@ -906,6 +906,8 @@ static bool CompileDag(const JsonObjectValue* root, BinaryWriter* writer, MemAll
   WriteStringPtr(main_seg, str_seg, FindStringValue(root, "DigestCacheFileNameTmp", ".tundra2.digestcache.tmp"));
   
   WriteStringPtr(main_seg, str_seg, FindStringValue(root, "BuildTitle", "Tundra"));
+  WriteStringPtr(main_seg, str_seg, FindStringValue(root, "StructuredLogFileName"));
+
   BinarySegmentWriteInt32(main_seg, (int) FindIntValue(root, "ForceDagRebuild", 0));
 
   HashTableDestroy(&shared_strings);

--- a/src/DigestCache.hpp
+++ b/src/DigestCache.hpp
@@ -68,6 +68,8 @@ namespace t2
   bool DigestCacheGet(DigestCache* self, const char* filename, uint32_t hash, uint64_t timestamp, HashDigest* digest_out);
 
   void DigestCacheSet(DigestCache* self, const char* filename, uint32_t hash, uint64_t timestamp, const HashDigest& digest);
+
+  bool DigestCacheHasChanged(DigestCache* self, const char* filename, uint32_t hash);
 }
 
 #endif

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -176,6 +176,30 @@ void DriverShowTargets(Driver* self)
   }
 }
 
+void DriverReportStartup(Driver* self, const char** targets, int target_count)
+{
+  JsonWriter msg;
+  JsonWriteInit(&msg, &self->m_Heap);
+  JsonWriteStartObject(&msg);
+
+  JsonWriteKeyName(&msg, "msg");
+  JsonWriteValueString(&msg, "init");
+
+  JsonWriteKeyName(&msg, "dagFile");
+  JsonWriteValueString(&msg, self->m_Options.m_DAGFileName);
+
+  JsonWriteKeyName(&msg, "targets");
+  JsonWriteStartArray(&msg);
+  for (int i = 0; i < target_count; ++i)
+    JsonWriteValueString(&msg, targets[i]);
+  JsonWriteEndArray(&msg);
+
+  JsonWriteEndObject(&msg);
+
+  LogStructured(&msg);
+  JsonWriteDestroy(&msg);
+}
+
 bool DriverInitData(Driver* self)
 {
   ProfilerScope prof_scope("Tundra InitData", 0);

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -179,8 +179,10 @@ void DriverShowTargets(Driver* self)
 
 void DriverReportStartup(Driver* self, const char** targets, int target_count)
 {
+  MemAllocLinearScope allocScope(&self->m_Allocator);
+
   JsonWriter msg;
-  JsonWriteInit(&msg, &self->m_Heap);
+  JsonWriteInit(&msg, &self->m_Allocator);
   JsonWriteStartObject(&msg);
 
   JsonWriteKeyName(&msg, "msg");
@@ -198,7 +200,6 @@ void DriverReportStartup(Driver* self, const char** targets, int target_count)
   JsonWriteEndObject(&msg);
 
   LogStructured(&msg);
-  JsonWriteDestroy(&msg);
 }
 
 bool DriverInitData(Driver* self)

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -183,6 +183,8 @@ bool DriverInitData(Driver* self)
   if (!DriverPrepareDag(self, s_DagFileName))
     return false;
 
+  SetStructuredLogFileName(self->m_DagData->m_StructuredLogFileName);
+
   DigestCacheInit(&self->m_DigestCache, MB(128), self->m_DagData->m_DigestCacheFileName);
 
   LoadFrozenData<StateData>(self->m_DagData->m_StateFileName, &self->m_StateFile, &self->m_StateData);

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -992,6 +992,35 @@ bool DriverSaveBuildState(Driver* self)
     }
 
     BinarySegmentWriteUint32(state_seg, (uint32_t)now/millisecondsInADay);
+
+    BinarySegmentWritePointer(state_seg, BinarySegmentPosition(string_seg));
+    BinarySegmentWriteStringData(string_seg, src_node->m_Action);
+
+    if (src_node->m_PreAction)
+    {
+      BinarySegmentWritePointer(state_seg, BinarySegmentPosition(string_seg));
+      BinarySegmentWriteStringData(string_seg, src_node->m_PreAction);
+    }
+    else
+    {
+      BinarySegmentWriteNullPointer(state_seg);
+    }
+
+    file_count = src_node->m_InputFiles.GetCount();
+    BinarySegmentWriteInt32(state_seg, file_count);
+    BinarySegmentWritePointer(state_seg, BinarySegmentPosition(array_seg));
+    for (int32_t i = 0; i < file_count; ++i)
+    {
+      uint64_t timestamp = 0;
+      FileInfo fileInfo = StatCacheStat(&self->m_StatCache, src_node->m_InputFiles[i].m_Filename, src_node->m_InputFiles[i].m_FilenameHash);
+      if (fileInfo.Exists())
+        timestamp = fileInfo.m_Timestamp;
+
+      BinarySegmentWriteUint64(array_seg, timestamp);
+
+      BinarySegmentWritePointer(array_seg, BinarySegmentPosition(string_seg));
+      BinarySegmentWriteStringData(string_seg, src_node->m_InputFiles[i].m_Filename);
+    }
   };
 
   auto save_node_state_old = [=](int build_result, const HashDigest* input_signature, const NodeStateData* src_node, const HashDigest* guid) -> void
@@ -1020,6 +1049,29 @@ bool DriverSaveBuildState(Driver* self)
     }
 
     BinarySegmentWriteUint32(state_seg, src_node->m_TimeStampOfLastUseInDays);
+
+    BinarySegmentWritePointer(state_seg, BinarySegmentPosition(string_seg));
+    BinarySegmentWriteStringData(string_seg, src_node->m_Action);
+
+    if (src_node->m_PreAction)
+    {
+      BinarySegmentWritePointer(state_seg, BinarySegmentPosition(string_seg));
+      BinarySegmentWriteStringData(string_seg, src_node->m_PreAction);
+    }
+    else
+    {
+      BinarySegmentWriteNullPointer(state_seg);
+    }
+
+    file_count = src_node->m_InputFiles.GetCount();
+    BinarySegmentWriteInt32(state_seg, file_count);
+    BinarySegmentWritePointer(state_seg, BinarySegmentPosition(array_seg));
+    for (int32_t i = 0; i < file_count; ++i)
+    {
+      BinarySegmentWriteUint64(array_seg, src_node->m_InputFiles[i].m_Timestamp);
+      BinarySegmentWritePointer(array_seg, BinarySegmentPosition(string_seg));
+      BinarySegmentWriteStringData(string_seg, src_node->m_InputFiles[i].m_Filename);
+    }
   };
 
   auto save_new = [=, &entry_count](size_t index) {

--- a/src/Driver.hpp
+++ b/src/Driver.hpp
@@ -99,6 +99,8 @@ void DriverShowHelp(Driver* self);
 
 void DriverShowTargets(Driver* self);
 
+void DriverReportStartup(Driver* self, const char** targets, int target_count);
+
 void DriverRemoveStaleOutputs(Driver* self);
 
 void DriverCleanOutputs(Driver* self);

--- a/src/FileSign.hpp
+++ b/src/FileSign.hpp
@@ -24,6 +24,8 @@ void ComputeFileSignature(
 
   HashDigest CalculateGlobSignatureFor(const char* path, MemAllocHeap* heap, MemAllocLinear* scratch);
 
+  bool ShouldUseSHA1SignatureFor(const char* filename, const uint32_t sha_extension_hashes[], int sha_extension_hash_count);
+
 }
 
 

--- a/src/JsonWriter.cpp
+++ b/src/JsonWriter.cpp
@@ -1,0 +1,104 @@
+#include "JsonWriter.hpp"
+#include <stdio.h>
+
+namespace t2
+{
+
+void JsonWriteInit(JsonWriter* writer, MemAllocHeap* heap)
+{
+    writer->m_Heap = heap;
+    BufferInitWithCapacity(&writer->m_Buffer, heap, 200);
+    JsonWriteReset(writer);
+}
+
+void JsonWriteDestroy(JsonWriter* writer)
+{
+    BufferDestroy(&writer->m_Buffer, writer->m_Heap);
+}
+
+void JsonWriteReset(JsonWriter* writer)
+{
+    BufferClear(&writer->m_Buffer);
+    writer->m_PrependComma = false;
+}
+
+void JsonWriteStartObject(JsonWriter* writer)
+{
+    if (writer->m_PrependComma)
+        BufferAppendOne(&writer->m_Buffer, writer->m_Heap, ',');
+
+    BufferAppendOne(&writer->m_Buffer, writer->m_Heap, '{');
+    writer->m_PrependComma = false;
+}
+
+void JsonWriteEndObject(JsonWriter* writer)
+{
+    BufferAppendOne(&writer->m_Buffer, writer->m_Heap, '}');
+    writer->m_PrependComma = true;
+}
+
+void JsonWriteStartArray(JsonWriter* writer)
+{
+    if (writer->m_PrependComma)
+        BufferAppendOne(&writer->m_Buffer, writer->m_Heap, ',');
+
+    BufferAppendOne(&writer->m_Buffer, writer->m_Heap, '[');
+    writer->m_PrependComma = false;
+}
+
+void JsonWriteEndArray(JsonWriter* writer)
+{
+    BufferAppendOne(&writer->m_Buffer, writer->m_Heap, ']');
+    writer->m_PrependComma = true;
+}
+
+void JsonWriteKeyName(JsonWriter* writer, const char* keyName)
+{
+    JsonWriteValueString(writer, keyName);
+    BufferAppendOne(&writer->m_Buffer, writer->m_Heap, ':');
+    writer->m_PrependComma = false;
+}
+
+void JsonWriteValueString(JsonWriter* writer, const char* value)
+{
+    if (writer->m_PrependComma)
+        BufferAppendOne(&writer->m_Buffer, writer->m_Heap, ',');
+
+    BufferAppendOne(&writer->m_Buffer, writer->m_Heap, '"');
+
+    while (*value != 0)
+    {
+        char ch = *(value++);
+        if (ch == '"')
+        {
+            BufferAppend(&writer->m_Buffer, writer->m_Heap, "\\\"", 2);
+        }
+        else if (ch == '\\')
+        {
+            BufferAppend(&writer->m_Buffer, writer->m_Heap, "\\\\", 2);
+        }
+        else
+        {
+            BufferAppendOne(&writer->m_Buffer, writer->m_Heap, ch);
+        }
+    }
+
+    BufferAppendOne(&writer->m_Buffer, writer->m_Heap, '"');
+
+    writer->m_PrependComma = true;
+}
+
+void JsonWriteValueInteger(JsonWriter* writer, int64_t value)
+{
+    if (writer->m_PrependComma)
+        BufferAppendOne(&writer->m_Buffer, writer->m_Heap, ',');
+
+    char buf[50];
+    snprintf(buf, 50, "%lli", value);
+
+    BufferAppend(&writer->m_Buffer, writer->m_Heap, buf, strlen(buf));
+
+    writer->m_PrependComma = true;
+}
+
+}

--- a/src/JsonWriter.hpp
+++ b/src/JsonWriter.hpp
@@ -1,0 +1,35 @@
+#ifndef JSONWRITER_HPP
+#define JSONWRITER_HPP
+
+#include "Buffer.hpp"
+
+namespace t2
+{
+
+struct JsonWriter
+{
+  MemAllocHeap* m_Heap;
+  Buffer<char> m_Buffer;
+  bool m_PrependComma;
+};
+
+void JsonWriteInit(JsonWriter* writer, MemAllocHeap* heap);
+void JsonWriteDestroy(JsonWriter* writer);
+
+void JsonWriteReset(JsonWriter* writer);
+
+void JsonWriteStartObject(JsonWriter* writer);
+void JsonWriteEndObject(JsonWriter* writer);
+
+void JsonWriteStartArray(JsonWriter* writer);
+void JsonWriteEndArray(JsonWriter* writer);
+
+
+void JsonWriteKeyName(JsonWriter* writer, const char* keyName);
+
+void JsonWriteValueString(JsonWriter* writer, const char* value);
+void JsonWriteValueInteger(JsonWriter* writer, int64_t value);
+
+}
+
+#endif

--- a/src/JsonWriter.hpp
+++ b/src/JsonWriter.hpp
@@ -1,22 +1,26 @@
 #ifndef JSONWRITER_HPP
 #define JSONWRITER_HPP
 
-#include "Buffer.hpp"
+#include <stdint.h>
+#include <stdio.h>
 
 namespace t2
 {
 
+struct MemAllocLinear;
+struct JsonBlock;
+
 struct JsonWriter
 {
-  MemAllocHeap* m_Heap;
-  Buffer<char> m_Buffer;
+  MemAllocLinear* m_Scratch;
+  JsonBlock* m_Head;
+  JsonBlock* m_Tail;
+  uint8_t*   m_Write;
   bool m_PrependComma;
+  uint64_t   m_TotalSize;
 };
 
-void JsonWriteInit(JsonWriter* writer, MemAllocHeap* heap);
-void JsonWriteDestroy(JsonWriter* writer);
-
-void JsonWriteReset(JsonWriter* writer);
+void JsonWriteInit(JsonWriter* writer, MemAllocLinear* heap);
 
 void JsonWriteStartObject(JsonWriter* writer);
 void JsonWriteEndObject(JsonWriter* writer);
@@ -24,11 +28,12 @@ void JsonWriteEndObject(JsonWriter* writer);
 void JsonWriteStartArray(JsonWriter* writer);
 void JsonWriteEndArray(JsonWriter* writer);
 
-
 void JsonWriteKeyName(JsonWriter* writer, const char* keyName);
 
 void JsonWriteValueString(JsonWriter* writer, const char* value);
 void JsonWriteValueInteger(JsonWriter* writer, int64_t value);
+
+void JsonWriteToFile(JsonWriter* writer, FILE* fp);
 
 }
 

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -447,6 +447,8 @@ int main(int argc, char* argv[])
     goto leave;
   }
 
+  DriverReportStartup(&driver, (const char**) argv, argc);
+
   if (driver.m_DagData->m_DaysToKeepUnreferencedNodesAround == -1)
     DriverRemoveStaleOutputs(&driver);
 

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -542,6 +542,8 @@ leave:
     }
   }
 
+  SetStructuredLogFileName(nullptr);
+
   return build_result == BuildResult::kOk ? 0 : 1;
 
   // Match up nodes to nodes in the build state

--- a/src/StateData.hpp
+++ b/src/StateData.hpp
@@ -7,13 +7,26 @@
 namespace t2
 {
 
+struct NodeInputFileData
+{
+  uint64_t     m_Timestamp;
+  FrozenString m_Filename;
+  uint8_t      m_Padding[4];
+};
+
+static_assert(sizeof(NodeInputFileData) == 16, "struct layout");
+
+
 struct NodeStateData
 {
-  int32_t                   m_BuildResult;
-  HashDigest                m_InputSignature;
-  FrozenArray<FrozenString> m_OutputFiles;
-  FrozenArray<FrozenString> m_AuxOutputFiles;
-  uint32_t                  m_TimeStampOfLastUseInDays;
+  int32_t                        m_BuildResult;
+  HashDigest                     m_InputSignature;
+  FrozenArray<FrozenString>      m_OutputFiles;
+  FrozenArray<FrozenString>      m_AuxOutputFiles;
+  uint32_t                       m_TimeStampOfLastUseInDays;
+  FrozenString                   m_Action;
+  FrozenString                   m_PreAction;
+  FrozenArray<NodeInputFileData> m_InputFiles;
 };
 
 struct StateData

--- a/src/StateData.hpp
+++ b/src/StateData.hpp
@@ -33,7 +33,7 @@ struct NodeStateData
 
 struct StateData
 {
-  static const uint32_t     MagicNumber = 0x15890103 ^ kTundraHashMagic;
+  static const uint32_t     MagicNumber = 0x15890104 ^ kTundraHashMagic;
 
   uint32_t                 m_MagicNumber;
 

--- a/src/StateData.hpp
+++ b/src/StateData.hpp
@@ -28,6 +28,7 @@ struct NodeStateData
   FrozenString                   m_Action;
   FrozenString                   m_PreAction;
   FrozenArray<NodeInputFileData> m_InputFiles;
+  FrozenArray<NodeInputFileData> m_ImplicitInputFiles;
 };
 
 struct StateData

--- a/src/StateData.hpp
+++ b/src/StateData.hpp
@@ -7,14 +7,15 @@
 namespace t2
 {
 
+#pragma pack(push, 4)
 struct NodeInputFileData
 {
   uint64_t     m_Timestamp;
   FrozenString m_Filename;
-  uint8_t      m_Padding[4];
 };
+#pragma pack(pop)
 
-static_assert(sizeof(NodeInputFileData) == 16, "struct layout");
+static_assert(sizeof(NodeInputFileData) == 12, "struct layout");
 
 
 struct NodeStateData

--- a/vs2017/libtundra/Tundra.natvis
+++ b/vs2017/libtundra/Tundra.natvis
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?> 
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+  <Type Name="t2::FrozenPtr&lt;*&gt;">
+    <SmartPointer Usage="Minimal">m_Offset == 0 ? nullptr : (const $T1*)(((uintptr_t)this) + m_Offset)</SmartPointer>
+  </Type>
+  <Type Name="t2::FrozenArray&lt;*&gt;">
+    <Expand>
+      <ArrayItems>
+        <Size>m_Count</Size>
+        <ValuePointer>m_Pointer.m_Offset == 0 ?  nullptr : (const $T1*)(((uintptr_t)&amp;m_Pointer) + m_Pointer.m_Offset)</ValuePointer>
+      </ArrayItems>
+    </Expand>
+  </Type>
+</AutoVisualizer>

--- a/vs2017/libtundra/libtundra.vcxproj
+++ b/vs2017/libtundra/libtundra.vcxproj
@@ -102,6 +102,7 @@
     <ClInclude Include="..\..\src\HashTable.hpp" />
     <ClInclude Include="..\..\src\IncludeScanner.hpp" />
     <ClInclude Include="..\..\src\JsonParse.hpp" />
+    <ClInclude Include="..\..\src\JsonWriter.hpp" />
     <ClInclude Include="..\..\src\MemAllocHeap.hpp" />
     <ClInclude Include="..\..\src\MemAllocLinear.hpp" />
     <ClInclude Include="..\..\src\MemoryMappedFile.hpp" />
@@ -144,6 +145,7 @@
     <ClCompile Include="..\..\src\HashTable.cpp" />
     <ClCompile Include="..\..\src\IncludeScanner.cpp" />
     <ClCompile Include="..\..\src\JsonParse.cpp" />
+    <ClCompile Include="..\..\src\JsonWriter.cpp" />
     <ClCompile Include="..\..\src\MemAllocHeap.cpp" />
     <ClCompile Include="..\..\src\MemAllocLinear.cpp" />
     <ClCompile Include="..\..\src\MemoryMappedFile.cpp" />


### PR DESCRIPTION
* Introduce a 'structured log' JSON output file for Tundra to log to, designed to be fairly human-readable but primarily easy for other tools to parse.
* When starting up, send an event to the structured log with info about the DAG used and targets requested.
* Change GUID calculation for nodes to be based on outputs instead of inputs, so that changing the inputs on a node doesn't change the GUID and allows us to reuse build state information for it correctly.
* When a node is encountered in the build queue for which we have no previous state, report an event to the structured log.
* When a node is encountered in the build queue for which we have a mismatched input signature, report an event to the structured log, and compare individual components of the signature to try and figure out exactly what changed.
* Introduces a .natvis file for the VS debugger.