### PR TITLE
Fix Windows10 test failures

### DIFF
--- a/src/ExecWin32.cpp
+++ b/src/ExecWin32.cpp
@@ -439,9 +439,9 @@ ExecResult ExecuteProcess(
   void* attributeListAllocation = nullptr;
   if (!stream_to_stdout)
   {
-    HANDLE handles_to_enherit[2] = { 0,0 };
-    sinfo.StartupInfo.hStdOutput = sinfo.StartupInfo.hStdError = handles_to_enherit[0] = GetOrCreateTempFileFor(job_id);
-    sinfo.StartupInfo.hStdInput = /* handles_to_enherit[1] = */ GetStdHandle(STD_INPUT_HANDLE);  // Inheriting stdin fails on Windows 7 with Win32 error 1450
+    HANDLE handle_to_inherit = INVALID_HANDLE_VALUE;
+    sinfo.StartupInfo.hStdOutput = sinfo.StartupInfo.hStdError = handle_to_inherit = GetOrCreateTempFileFor(job_id);
+    sinfo.StartupInfo.hStdInput = GetStdHandle(STD_INPUT_HANDLE);  // Inheriting stdin fails on Windows 7 with Win32 error 1450
     sinfo.StartupInfo.dwFlags |= STARTF_USESTDHANDLES;
     creationFlags |= EXTENDED_STARTUPINFO_PRESENT;
 
@@ -457,7 +457,7 @@ ExecResult ExecuteProcess(
     //but this call is supposed to succeed, so here we check it for returning ==0
     if (!InitializeProcThreadAttributeList(sinfo.lpAttributeList, 1, 0, &attributeListSize))
       CroakErrno("InitializeProcThreadAttributeList failed (2)");
-    if (!UpdateProcThreadAttribute(sinfo.lpAttributeList, 0, PROC_THREAD_ATTRIBUTE_HANDLE_LIST, handles_to_enherit, sizeof(handles_to_enherit), NULL, NULL))
+    if (!UpdateProcThreadAttribute(sinfo.lpAttributeList, 0, PROC_THREAD_ATTRIBUTE_HANDLE_LIST, &handle_to_inherit, sizeof(HANDLE), NULL, NULL))
       CroakErrno("UpdateProcThreadAttribute failed");
   }
 


### PR DESCRIPTION
We were incorrectly asking CreateProcess to inherit handle ID #0, which is not valid.