### PR TITLE
Add --silence-if-possible flag to suppress conclusion in no-op builds

### DIFF
--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -60,27 +60,28 @@ void DriverInitializeTundraFilePaths(DriverOptions* driverOptions)
 // Set default options.
 void DriverOptionsInit(DriverOptions* self)
 {
-  self->m_ShowHelp        = false;
-  self->m_DryRun          = false;
-  self->m_ForceDagRegen   = false;
-  self->m_ShowTargets     = false;
-  self->m_DebugMessages   = false;
-  self->m_Verbose         = false;
-  self->m_SpammyVerbose   = false;
-  self->m_DisplayStats    = false;
-  self->m_GenDagOnly      = false;
-  self->m_Quiet           = false;
-  self->m_Clean           = false;
-  self->m_Rebuild         = false;
-  self->m_IdeGen          = false;
-  self->m_DebugSigning    = false;
-  self->m_ContinueOnError = false;
-  self->m_ThreadCount     = GetCpuCount();
-  self->m_WorkingDir      = nullptr;
-  self->m_DAGFileName     = ".tundra2.dag";
-  self->m_ProfileOutput   = nullptr;
+  self->m_ShowHelp          = false;
+  self->m_DryRun            = false;
+  self->m_ForceDagRegen     = false;
+  self->m_ShowTargets       = false;
+  self->m_DebugMessages     = false;
+  self->m_Verbose           = false;
+  self->m_SpammyVerbose     = false;
+  self->m_DisplayStats      = false;
+  self->m_GenDagOnly        = false;
+  self->m_Quiet             = false;
+  self->m_SilenceIfPossible = false;
+  self->m_Clean             = false;
+  self->m_Rebuild           = false;
+  self->m_IdeGen            = false;
+  self->m_DebugSigning      = false;
+  self->m_ContinueOnError   = false;
+  self->m_ThreadCount       = GetCpuCount();
+  self->m_WorkingDir        = nullptr;
+  self->m_DAGFileName       = ".tundra2.dag";
+  self->m_ProfileOutput     = nullptr;
   #if defined(TUNDRA_WIN32)
-  self->m_RunUnprotected  = false;
+  self->m_RunUnprotected    = false;
 #endif
 }
 

--- a/src/Driver.hpp
+++ b/src/Driver.hpp
@@ -30,6 +30,7 @@ struct DriverOptions
   bool        m_DisplayStats;
   bool        m_GenDagOnly;
   bool        m_Quiet;
+  bool        m_SilenceIfPossible;
   bool        m_IdeGen;
   bool        m_Clean;
   bool        m_Rebuild;

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -56,6 +56,8 @@ static const struct OptionTemplate
     "Enable verbose build messages" },
   { 'q', "quiet", OptionType::kBool, offsetof(t2::DriverOptions, m_Quiet),
     "Be quiet" },
+  { 'Q', "silence-if-possible", OptionType::kBool, offsetof(t2::DriverOptions, m_SilenceIfPossible),
+    "If no actions taken, don't display a conclusion message" },
   { 'c', "clean", OptionType::kBool, offsetof(t2::DriverOptions, m_Clean),
     "Clean targets (remove output files)" },
   { 'l', "rebuild", OptionType::kBool, offsetof(t2::DriverOptions, m_Rebuild),
@@ -528,7 +530,7 @@ leave:
 
   double total_time = TimerDiffSeconds(start_time, TimerGet());
   bool haveTitle = strlen(buildTitle) > 0;
-  if (haveTitle)
+  if (haveTitle && (build_result != 0 || g_Stats.m_ExecCount > 0 || !options.m_SilenceIfPossible))
   {
     if (total_time < 60.0)
     {


### PR DESCRIPTION
If Tundra found no nodes that needed to be run, it currently still outputs a "build success (0.07 seconds), 0 items updated" message. This is OK for a main build, but when we are running Tundra as a prepass - e.g. for Bee bootstrapping - then it's quite annoying.

This flag suppresses the conclusion line if the build succeeded with no actions performed.