### PR TITLE
Record node indices and action root PIDs in profiler output

### DIFF
--- a/src/BuildQueue.cpp
+++ b/src/BuildQueue.cpp
@@ -891,7 +891,7 @@ namespace t2
     {
       Log(kSpam, "Launching pre-action process");
       TimingScope timing_scope(&g_Stats.m_ExecCount, &g_Stats.m_ExecTimeCycles);
-      ProfilerScope prof_scope("Pre-build", job_id);
+      ProfilerScope prof_scope("Pre-build", job_id, node->m_MmapData->m_OriginalIndex);
       last_cmd_line = pre_cmd_line;
       result = ExecuteProcess(pre_cmd_line, env_count, env_vars, thread_state->m_Queue->m_Config.m_Heap, job_id, false, SlowCallback, &slowCallbackData, 1);
       Log(kSpam, "Process return code %d", result.m_ReturnCode);
@@ -902,13 +902,13 @@ namespace t2
     {
       Log(kSpam, "Launching process");
       TimingScope timing_scope(&g_Stats.m_ExecCount, &g_Stats.m_ExecTimeCycles);
-      ProfilerScope prof_scope(annotation, job_id);
+      ProfilerScope prof_scope(annotation, job_id, node->m_MmapData->m_OriginalIndex);
       if (isWriteFileAction)
         result = WriteTextFile(node_data->m_Action, node_data->m_OutputFiles[0].m_Filename, thread_state->m_Queue->m_Config.m_Heap);
       else
       {
         last_cmd_line = cmd_line;
-        result = ExecuteProcess(cmd_line, env_count, env_vars, thread_state->m_Queue->m_Config.m_Heap, job_id, false, SlowCallback, &slowCallbackData);
+        result = ExecuteProcess(cmd_line, env_count, env_vars, thread_state->m_Queue->m_Config.m_Heap, job_id, false, SlowCallback, &slowCallbackData, 1, prof_scope.m_Evt ? &prof_scope.m_Evt->m_PID : nullptr);
         passedOutputValidation = ValidateExecResultAgainstAllowedOutput(&result, node_data);
       }
       Log(kSpam, "Process return code %d", result.m_ReturnCode);

--- a/src/Exec.hpp
+++ b/src/Exec.hpp
@@ -3,6 +3,7 @@
 
 #include "stddef.h"
 #include <thread>
+#include "Config.hpp"
 
 namespace t2
 {
@@ -38,16 +39,23 @@ namespace t2
   void ExecInit();
   void EmitOutputBytesToDestination(ExecResult* execResult, const char* text, size_t count);
 
+#if defined(TUNDRA_WIN32)
+  typedef uint32_t TundraPID;
+#else
+  typedef pid_t TundraPID;
+#endif
+
   ExecResult ExecuteProcess(
         const char*         cmd_line,
         int                 env_count,
         const EnvVariable*  env_vars,
         MemAllocHeap*       heap,
         int                 job_id,
-        bool                stream_output_to_stdout,
+        bool                stream_output_to_stdout = false,
         int (*callback_on_slow)(void* user_data) = nullptr,
         void*               callback_on_slow_userdata = nullptr,
-        int                 time_until_first_callback = 1
+        int                 time_until_first_callback = 1,
+        TundraPID*          out_pid = nullptr
         );
 
 }

--- a/src/ExecUnix.cpp
+++ b/src/ExecUnix.cpp
@@ -76,7 +76,8 @@ ExecuteProcess(
 		bool stream_to_stdout,
 		int (*callback_on_slow)(void* user_data),
         void* callback_on_slow_userdata,
-		int time_to_first_slow_callback)
+		int time_to_first_slow_callback,
+    int* out_pid)
 {
   ExecResult result;
 
@@ -158,6 +159,9 @@ ExecuteProcess(
 		int rfd_count = 2;
 		int rfds[2];
 		fd_set read_fds;
+
+    if (out_pid != nullptr)
+      *out_pid = child;
 
 		rfds[0] = stdout_pipe[pipe_read];
 		rfds[1] = stderr_pipe[pipe_read];

--- a/src/ExecWin32.cpp
+++ b/src/ExecWin32.cpp
@@ -423,10 +423,11 @@ ExecResult ExecuteProcess(
   const EnvVariable*  env_vars,
   MemAllocHeap*       heap,
   int                 job_id,
-  bool                stream_to_stdout = false,
+  bool                stream_to_stdout,
   int(*callback_on_slow)(void* user_data),
   void* callback_on_slow_userdata,
-  int                 time_until_first_callback
+  int                 time_until_first_callback,
+  TundraPID*          out_pid
   )
 {
   STARTUPINFOEXW sinfo;
@@ -497,6 +498,9 @@ ExecResult ExecuteProcess(
 
   if (!CreateProcessW(NULL, buffer_wide, NULL, NULL, enherit_handles, creationFlags, env_block_wide, NULL, &sinfo.StartupInfo, &pinfo))
     CroakAbort("ERROR: Couldn't launch process. Win32 error = %d", (int)GetLastError());
+
+  if (out_pid != nullptr)
+    *out_pid = GetProcessId(pinfo.hProcess);
 
   if (!stream_to_stdout)
   {


### PR DESCRIPTION
When profiling is enabled, capture both the DAG node index that a profiler entry corresponds to (if appropriate), and for action nodes that launch external processes, capture the PID of the process that has been launched.

The PID will allow us to correlate profiler data with system tracing tools like Process Monitor or DTrace, and the node index will let us connect it back to the DAG, giving us a pipeline for connecting DAG nodes to their resulting process and IO activity. We can then explore using this to verify that a node's inputs and outputs are fully described.

This is being done in the profiler data, rather than the structured log, because unlike the structured log it is _not_ data that we are going to need all the time; it's more going to be something that we enable specifically when we are investigating something about the build and running other diagnostic processes at the same time. (Right now it's moot, as profiling is always on, but in the future I can imagine us switching it off).