### PR TITLE
More informative error messages when FileSignatures data is bad

### DIFF
--- a/src/DagGenerator.cpp
+++ b/src/DagGenerator.cpp
@@ -844,7 +844,7 @@ static bool CompileDag(const JsonObjectValue* root, BinaryWriter* writer, MemAll
         
         if (!path)
         {
-          fprintf(stderr, "bad FileSignatures data\n");
+          fprintf(stderr, "bad FileSignatures data: could not get 'File' member for object at index %zu\n", i);
           return false;
         }
 
@@ -856,7 +856,7 @@ static bool CompileDag(const JsonObjectValue* root, BinaryWriter* writer, MemAll
       }
       else
       {
-        fprintf(stderr, "bad FileSignatures data\n");
+        fprintf(stderr, "bad FileSignatures data: array entry at index %zu was not an Object\n", i);
         return false;
       }
     }


### PR DESCRIPTION
Someone ran into a problem with their local checkout, where this error message was popping up. The issue turned out to be a problem with their Mercurial largefiles, but it'd be good to improve the error message to be more informative in any case.