### PR TITLE
Fix Win7

### DIFF
--- a/src/ExecWin32.cpp
+++ b/src/ExecWin32.cpp
@@ -441,7 +441,7 @@ ExecResult ExecuteProcess(
   {
     HANDLE handles_to_enherit[2] = { 0,0 };
     sinfo.StartupInfo.hStdOutput = sinfo.StartupInfo.hStdError = handles_to_enherit[0] = GetOrCreateTempFileFor(job_id);
-    sinfo.StartupInfo.hStdInput = handles_to_enherit[1] = GetStdHandle(STD_INPUT_HANDLE);
+    sinfo.StartupInfo.hStdInput = /* handles_to_enherit[1] = */ GetStdHandle(STD_INPUT_HANDLE);  // Inheriting stdin fails on Windows 7 with Win32 error 1450
     sinfo.StartupInfo.dwFlags |= STARTF_USESTDHANDLES;
     creationFlags |= EXTENDED_STARTUPINFO_PRESENT;
 

--- a/src/ExecWin32.cpp
+++ b/src/ExecWin32.cpp
@@ -37,6 +37,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <windows.h>
+#include <VersionHelpers.h>
 #include <thread>
 
 namespace t2
@@ -439,11 +440,20 @@ ExecResult ExecuteProcess(
   void* attributeListAllocation = nullptr;
   if (!stream_to_stdout)
   {
-    HANDLE handle_to_inherit = INVALID_HANDLE_VALUE;
-    sinfo.StartupInfo.hStdOutput = sinfo.StartupInfo.hStdError = handle_to_inherit = GetOrCreateTempFileFor(job_id);
-    sinfo.StartupInfo.hStdInput = GetStdHandle(STD_INPUT_HANDLE);  // Inheriting stdin fails on Windows 7 with Win32 error 1450
+    sinfo.StartupInfo.hStdOutput = sinfo.StartupInfo.hStdError = GetOrCreateTempFileFor(job_id);
+    sinfo.StartupInfo.hStdInput = GetStdHandle(STD_INPUT_HANDLE);  
     sinfo.StartupInfo.dwFlags |= STARTF_USESTDHANDLES;
     creationFlags |= EXTENDED_STARTUPINFO_PRESENT;
+
+    HANDLE handles_to_inherit[2];
+    size_t num_handles_to_inherit = 1;
+    handles_to_inherit[0] = sinfo.StartupInfo.hStdOutput;
+
+    if (IsWindows8OrGreater()) // Inheriting stdin fails on Windows 7 with Win32 error 1450
+    {
+      handles_to_inherit[1] = sinfo.StartupInfo.hStdInput;
+      ++num_handles_to_inherit;
+    }
 
     SIZE_T attributeListSize = 0;
 
@@ -457,7 +467,7 @@ ExecResult ExecuteProcess(
     //but this call is supposed to succeed, so here we check it for returning ==0
     if (!InitializeProcThreadAttributeList(sinfo.lpAttributeList, 1, 0, &attributeListSize))
       CroakErrno("InitializeProcThreadAttributeList failed (2)");
-    if (!UpdateProcThreadAttribute(sinfo.lpAttributeList, 0, PROC_THREAD_ATTRIBUTE_HANDLE_LIST, &handle_to_inherit, sizeof(HANDLE), NULL, NULL))
+    if (!UpdateProcThreadAttribute(sinfo.lpAttributeList, 0, PROC_THREAD_ATTRIBUTE_HANDLE_LIST, handles_to_inherit, sizeof(HANDLE) * num_handles_to_inherit, NULL, NULL))
       CroakErrno("UpdateProcThreadAttribute failed");
   }
 

--- a/src/ExecWin32.cpp
+++ b/src/ExecWin32.cpp
@@ -439,9 +439,9 @@ ExecResult ExecuteProcess(
   void* attributeListAllocation = nullptr;
   if (!stream_to_stdout)
   {
-    HANDLE handles_to_enherit[2] = { 0,0 };
-    sinfo.StartupInfo.hStdOutput = sinfo.StartupInfo.hStdError = handles_to_enherit[0] = GetOrCreateTempFileFor(job_id);
-    sinfo.StartupInfo.hStdInput = /* handles_to_enherit[1] = */ GetStdHandle(STD_INPUT_HANDLE);  // Inheriting stdin fails on Windows 7 with Win32 error 1450
+    HANDLE handle_to_inherit = INVALID_HANDLE_VALUE;
+    sinfo.StartupInfo.hStdOutput = sinfo.StartupInfo.hStdError = handle_to_inherit = GetOrCreateTempFileFor(job_id);
+    sinfo.StartupInfo.hStdInput = GetStdHandle(STD_INPUT_HANDLE);  // Inheriting stdin fails on Windows 7 with Win32 error 1450
     sinfo.StartupInfo.dwFlags |= STARTF_USESTDHANDLES;
     creationFlags |= EXTENDED_STARTUPINFO_PRESENT;
 
@@ -457,7 +457,7 @@ ExecResult ExecuteProcess(
     //but this call is supposed to succeed, so here we check it for returning ==0
     if (!InitializeProcThreadAttributeList(sinfo.lpAttributeList, 1, 0, &attributeListSize))
       CroakErrno("InitializeProcThreadAttributeList failed (2)");
-    if (!UpdateProcThreadAttribute(sinfo.lpAttributeList, 0, PROC_THREAD_ATTRIBUTE_HANDLE_LIST, handles_to_enherit, sizeof(handles_to_enherit), NULL, NULL))
+    if (!UpdateProcThreadAttribute(sinfo.lpAttributeList, 0, PROC_THREAD_ATTRIBUTE_HANDLE_LIST, &handle_to_inherit, sizeof(HANDLE), NULL, NULL))
       CroakErrno("UpdateProcThreadAttribute failed");
   }
 


### PR DESCRIPTION
Bring back the Win7 fixes we attempted before, but this time, only apply them if the OS actually *is* Win7 (or, more accurately, 'earlier than Win8').