### PR TITLE
Multiple dags

### DIFF
--- a/src/BinaryData.hpp
+++ b/src/BinaryData.hpp
@@ -47,6 +47,8 @@ private:
 };
 
 typedef FrozenPtr<const char> FrozenString;
+  
+const uint64_t storage_for_empty_frozenarrays = 0;
 
 template <typename T>
 class FrozenArray
@@ -68,8 +70,13 @@ public:
     return m_Pointer[index];
   }
 
+  static const FrozenArray<T>& empty()
+  {
+      return *reinterpret_cast<const FrozenArray<T>*>(&storage_for_empty_frozenarrays);
+  }
+
 private:
-  FrozenArray();
+  FrozenArray() {}
   ~FrozenArray();
   FrozenArray& operator=(const FrozenArray&);
   FrozenArray(const FrozenArray&);

--- a/src/BinaryData.hpp
+++ b/src/BinaryData.hpp
@@ -76,7 +76,7 @@ public:
   }
 
 private:
-  FrozenArray() {}
+  FrozenArray();
   ~FrozenArray();
   FrozenArray& operator=(const FrozenArray&);
   FrozenArray(const FrozenArray&);

--- a/src/DagData.hpp
+++ b/src/DagData.hpp
@@ -132,9 +132,11 @@ struct PassData
 
 struct DagData
 {
-  static const uint32_t         MagicNumber   = 0x1589013f ^ kTundraHashMagic;
+  static const uint32_t         MagicNumber   = 0x2B89013f ^ kTundraHashMagic;
 
   uint32_t                      m_MagicNumber;
+
+  uint32_t                      m_HashedIdentifier;
 
   int32_t                       m_NodeCount;
   FrozenPtr<HashDigest>         m_NodeGuids;

--- a/src/DagGenerator.cpp
+++ b/src/DagGenerator.cpp
@@ -653,6 +653,7 @@ static bool CompileDag(const JsonObjectValue* root, BinaryWriter* writer, MemAll
   const JsonArrayValue  *nodes         = FindArrayValue(root, "Nodes");
   const JsonArrayValue  *passes        = FindArrayValue(root, "Passes");
   const JsonArrayValue  *scanners      = FindArrayValue(root, "Scanners");
+  const char*           identifier     = FindStringValue(root, "Identifier", "default");
 
   if (EmptyArray(passes))
   {
@@ -678,6 +679,8 @@ static bool CompileDag(const JsonObjectValue* root, BinaryWriter* writer, MemAll
 
   // Write magic number
   BinarySegmentWriteUint32(main_seg, DagData::MagicNumber);
+
+  BinarySegmentWriteUint32(main_seg, Djb2Hash(identifier));
 
   // Compute node guids and index remapping table.
   // FIXME: this just leaks

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -451,8 +451,7 @@ int main(int argc, char* argv[])
 
   DriverReportStartup(&driver, (const char**) argv, argc);
 
-  if (driver.m_DagData->m_DaysToKeepUnreferencedNodesAround == -1)
-    DriverRemoveStaleOutputs(&driver);
+  DriverRemoveStaleOutputs(&driver);
 
   // Prepare list of nodes to build/clean/rebuild
   if (!DriverPrepareNodes(&driver, (const char**) argv, argc))

--- a/src/StateData.hpp
+++ b/src/StateData.hpp
@@ -28,11 +28,13 @@ struct NodeStateData
   FrozenString                   m_PreAction;
   FrozenArray<NodeInputFileData> m_InputFiles;
   FrozenArray<NodeInputFileData> m_ImplicitInputFiles;
+
+  FrozenArray<uint32_t>          m_DagsWeHaveSeenThisNodeInPreviously;
 };
 
 struct StateData
 {
-  static const uint32_t     MagicNumber = 0x15890104 ^ kTundraHashMagic;
+  static const uint32_t     MagicNumber = 0x1589A105 ^ kTundraHashMagic;
 
   uint32_t                 m_MagicNumber;
 

--- a/src/StateData.hpp
+++ b/src/StateData.hpp
@@ -24,7 +24,6 @@ struct NodeStateData
   HashDigest                     m_InputSignature;
   FrozenArray<FrozenString>      m_OutputFiles;
   FrozenArray<FrozenString>      m_AuxOutputFiles;
-  uint32_t                       m_TimeStampOfLastUseInDays;
   FrozenString                   m_Action;
   FrozenString                   m_PreAction;
   FrozenArray<NodeInputFileData> m_InputFiles;


### PR DESCRIPTION
For each node in the buildstate, store an array of dag identifiers in which we've seen this node. Once we run a build from a dag which used to have a certain node, we delete the node. This allows unity like
deployments where the buildprogram can generate many different dags that all need to operate on the same buildstate.