### PR TITLE
Support for an action that has one or more valid non-zero exit code

### DIFF
--- a/src/BuildQueue.cpp
+++ b/src/BuildQueue.cpp
@@ -957,7 +957,17 @@ namespace t2
       SignalSet("child processes was aborted");
     }
 
-    if (0 == result.m_ReturnCode && passedOutputValidation < ValidationResult::UnexpectedConsoleOutputFail)
+    bool isReturnCodeOK = false;
+    for (int32_t exitCode : node_data->m_AllowedExitCodes)
+    {
+      if (result.m_ReturnCode != exitCode)
+        continue;
+
+      isReturnCodeOK = true;
+      break;
+    }
+
+    if (isReturnCodeOK && passedOutputValidation < ValidationResult::UnexpectedConsoleOutputFail)
     {
       return BuildProgress::kSucceeded;
     }
@@ -966,7 +976,7 @@ namespace t2
       // Clean up output files after a failed build unless they are precious,
       // or unless the failure was from failing to write one of them
       if (0 == (NodeData::kFlagPreciousOutputs & node_data->m_Flags) &&
-        !(0 == result.m_ReturnCode && passedOutputValidation == ValidationResult::UnwrittenOutputFileFail))
+        !(isReturnCodeOK && passedOutputValidation == ValidationResult::UnwrittenOutputFileFail))
       {
         for (const FrozenFileAndHash& output : node_data->m_OutputFiles)
         {

--- a/src/BuildQueue.cpp
+++ b/src/BuildQueue.cpp
@@ -957,17 +957,7 @@ namespace t2
       SignalSet("child processes was aborted");
     }
 
-    bool isReturnCodeOK = false;
-    for (int32_t exitCode : node_data->m_AllowedExitCodes)
-    {
-      if (result.m_ReturnCode != exitCode)
-        continue;
-
-      isReturnCodeOK = true;
-      break;
-    }
-
-    if (isReturnCodeOK && passedOutputValidation < ValidationResult::UnexpectedConsoleOutputFail)
+    if (IsAllowedExitCode(result.m_ReturnCode, node_data) && passedOutputValidation < ValidationResult::UnexpectedConsoleOutputFail)
     {
       return BuildProgress::kSucceeded;
     }
@@ -976,7 +966,7 @@ namespace t2
       // Clean up output files after a failed build unless they are precious,
       // or unless the failure was from failing to write one of them
       if (0 == (NodeData::kFlagPreciousOutputs & node_data->m_Flags) &&
-        !(isReturnCodeOK && passedOutputValidation == ValidationResult::UnwrittenOutputFileFail))
+        !(IsAllowedExitCode(result.m_ReturnCode, node_data) && passedOutputValidation == ValidationResult::UnwrittenOutputFileFail))
       {
         for (const FrozenFileAndHash& output : node_data->m_OutputFiles)
         {

--- a/src/DagData.hpp
+++ b/src/DagData.hpp
@@ -119,6 +119,7 @@ struct NodeData
   FrozenArray<FrozenFileAndHash>  m_AuxOutputFiles;
   FrozenArray<FrozenFileAndHash>  m_FrontendResponseFiles;
   FrozenArray<FrozenString>       m_AllowedOutputSubstrings;
+  FrozenArray<int32_t>            m_AllowedExitCodes;
   FrozenArray<EnvVarData>         m_EnvVars;
   FrozenPtr<ScannerData>          m_Scanner;
   uint32_t                        m_Flags;
@@ -132,7 +133,7 @@ struct PassData
 
 struct DagData
 {
-  static const uint32_t         MagicNumber   = 0x2B89013f ^ kTundraHashMagic;
+  static const uint32_t         MagicNumber   = 0x2B89014f ^ kTundraHashMagic;
 
   uint32_t                      m_MagicNumber;
 

--- a/src/DagGenerator.cpp
+++ b/src/DagGenerator.cpp
@@ -254,6 +254,7 @@ static bool WriteNodes(
     const int             scanner_index = (int) FindIntValue(node, "ScannerIndex", -1);
     const JsonArrayValue *frontend_rsps = FindArrayValue(node, "FrontendResponseFiles");
     const JsonArrayValue *allowedOutputSubstrings = FindArrayValue(node, "AllowedOutputSubstrings");
+    const JsonArrayValue *allowedExitCodes = FindArrayValue(node, "AllowedExitCodes");
     const char          *writetextfile_payload = FindStringValue(node, "WriteTextFilePayload");
 
     if (writetextfile_payload == nullptr)
@@ -323,6 +324,23 @@ static bool WriteNodes(
     {
       BinarySegmentWriteInt32(node_data_seg, 0);
       BinarySegmentWriteNullPointer(node_data_seg);
+    }
+
+    if (allowedExitCodes)
+    {
+      BinarySegmentWriteInt32(node_data_seg, (int)allowedExitCodes->m_Count);
+      BinarySegmentAlign(array2_seg, 4);
+      BinarySegmentWritePointer(node_data_seg, BinarySegmentPosition(array2_seg));
+      for (size_t i = 0; i < allowedExitCodes->m_Count; i++)
+        BinarySegmentWriteInt32(array2_seg, (int32_t)allowedExitCodes->m_Values[i]->AsNumber()->m_Number);
+    }
+    else
+    {
+      // Always write a 1-length array containing exit code 0 if not specified
+      BinarySegmentWriteInt32(node_data_seg, 1);
+      BinarySegmentAlign(array2_seg, 4);
+      BinarySegmentWritePointer(node_data_seg, BinarySegmentPosition(array2_seg));
+      BinarySegmentWriteInt32(array2_seg, 0);
     }
 
     // Environment variables

--- a/src/NodeResultPrinting.cpp
+++ b/src/NodeResultPrinting.cpp
@@ -209,19 +209,7 @@ void PrintNodeResult(
   bool* untouched_outputs)
 {
     int processedNodeCount = ++queue->m_ProcessedNodeCount;
-
-    bool failed = true;
-    for (int32_t exitCode : node_data->m_AllowedExitCodes)
-    {
-      if (exitCode != result->m_ReturnCode)
-        continue;
-
-      failed = false;
-      break;
-    }
-
-    failed |= result->m_WasSignalled || validationResult >= ValidationResult::UnexpectedConsoleOutputFail;
-
+    bool failed = !IsAllowedExitCode(result->m_ReturnCode, node_data) || result->m_WasSignalled || validationResult >= ValidationResult::UnexpectedConsoleOutputFail;
     bool verbose = (failed && !result->m_WasAborted) || always_verbose;
 
     int maxDigits = ceil(log10(queue->m_Config.m_MaxNodes+1)); 

--- a/src/NodeResultPrinting.cpp
+++ b/src/NodeResultPrinting.cpp
@@ -209,7 +209,19 @@ void PrintNodeResult(
   bool* untouched_outputs)
 {
     int processedNodeCount = ++queue->m_ProcessedNodeCount;
-    bool failed = result->m_ReturnCode != 0 || result->m_WasSignalled || validationResult >= ValidationResult::UnexpectedConsoleOutputFail;
+
+    bool failed = true;
+    for (int32_t exitCode : node_data->m_AllowedExitCodes)
+    {
+      if (exitCode != result->m_ReturnCode)
+        continue;
+
+      failed = false;
+      break;
+    }
+
+    failed |= result->m_WasSignalled || validationResult >= ValidationResult::UnexpectedConsoleOutputFail;
+
     bool verbose = (failed && !result->m_WasAborted) || always_verbose;
 
     int maxDigits = ceil(log10(queue->m_Config.m_MaxNodes+1)); 

--- a/src/OutputValidation.cpp
+++ b/src/OutputValidation.cpp
@@ -47,4 +47,15 @@ ValidationResult ValidateExecResultAgainstAllowedOutput(ExecResult* result, cons
     return allowOutput ? ValidationResult::Pass : ValidationResult::UnexpectedConsoleOutputFail;
 }
 
+bool IsAllowedExitCode(int32_t code, const NodeData* node_data)
+{
+  for (int32_t exitCode : node_data->m_AllowedExitCodes)
+  {
+    if (exitCode == code)
+      return true;
+  }
+
+  return false;
+}
+
 }

--- a/src/OutputValidation.hpp
+++ b/src/OutputValidation.hpp
@@ -1,6 +1,8 @@
 #ifndef OUTPUT_VALIDATION_HPP
 #define OUTPUT_VALIDATION_HPP
 
+#include <stdint.h>
+
 namespace t2
 {
     struct ExecResult;
@@ -15,5 +17,7 @@ namespace t2
     };
 
     ValidationResult ValidateExecResultAgainstAllowedOutput(ExecResult* result, const NodeData* node_data);
+
+    bool IsAllowedExitCode(int32_t code, const NodeData* node_data);
 }
 #endif


### PR DESCRIPTION
Various tools that we want to run (e.g. Robocopy) emit non-zero return values in some successful situations. This PR adds support for nodes to specify their acceptable return values (defaulting to 0 if the node does not specify).