### PR TITLE
Make tundra always print out why it decided to rerun the frontend,  a…

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -533,7 +533,7 @@ leave:
   {
     if (total_time < 60.0)
     {
-      PrintConcludingMessage(build_result == 0, "*** %s %s (%.2f seconds), %d items updated", buildTitle, BuildResult::Names[build_result], total_time, g_Stats.m_ExecCount);
+      PrintServiceMessage(build_result == 0 ? MessageStatusLevel::Success : MessageStatusLevel::Failure, "*** %s %s (%.2f seconds), %d items updated", buildTitle, BuildResult::Names[build_result], total_time, g_Stats.m_ExecCount);
     }
     else
     {
@@ -541,7 +541,7 @@ leave:
       int h = t / 3600; t -= h * 3600;
       int m = t /   60; t -= m *   60;
       int s = t;
-      PrintConcludingMessage(build_result == 0, "*** %s %s (%.2f seconds - %d:%02d:%02d), %d items updated", buildTitle, BuildResult::Names[build_result], total_time, h, m, s, g_Stats.m_ExecCount);
+      PrintServiceMessage(build_result == 0 ? MessageStatusLevel::Success : MessageStatusLevel::Failure, "*** %s %s (%.2f seconds - %d:%02d:%02d), %d items updated", buildTitle, BuildResult::Names[build_result], total_time, h, m, s, g_Stats.m_ExecCount);
     }
   }
 

--- a/src/NodeResultPrinting.hpp
+++ b/src/NodeResultPrinting.hpp
@@ -10,6 +10,17 @@ struct ExecResult;
 struct NodeData;
 struct BuildQueue;
 
+namespace MessageStatusLevel
+{
+  enum Enum
+  {
+    Success     = 0,
+    Failure     = 1,
+    Warning     = 2,
+    Info        = 3,
+  };
+}
+
 void InitNodeResultPrinting();
 void PrintNodeResult(
   ExecResult* result,
@@ -21,7 +32,8 @@ void PrintNodeResult(
   ValidationResult validationResult,
   bool* untouched_outputs);
 int PrintNodeInProgress(const NodeData* node_data, uint64_t time_of_start, const BuildQueue* queue);
-void PrintConcludingMessage(bool success, const char* formatString, ...);
+void PrintLineWithDurationAndAnnotation(uint64_t time_exec_started, int nodeCount, int max_nodes, MessageStatusLevel::Enum status_level, const char* annotation);
+void PrintServiceMessage(MessageStatusLevel::Enum statusLevel, const char* formatString, ...);
 void StripAnsiColors(char* buffer);
 }
 #endif


### PR DESCRIPTION
…nd make it print a warning if checking file & glob signatures takes >1 second.

![screenshot](
https://www.dropbox.com/s/od5it49s6b5k9gz/Screenshot%202018-08-20%2016.25.51.png?dl=0)