### PR TITLE
Truncate long value strings in structured json output to max 64kb

### DIFF
--- a/src/BuildQueue.cpp
+++ b/src/BuildQueue.cpp
@@ -322,6 +322,19 @@ namespace t2
     }
   }
 
+  static void ReportValueWithOptionalTruncation(JsonWriter* msg, const char* keyName, const char* truncatedKeyName, const FrozenString& value)
+  {
+    size_t len = strlen(value);
+    const size_t maxLen = KB(64);
+    JsonWriteKeyName(msg, keyName);
+    JsonWriteValueString(msg, value, maxLen);
+    if (len > maxLen)
+    {
+      JsonWriteKeyName(msg, truncatedKeyName);
+      JsonWriteValueInteger(msg, 1);
+    }
+  }
+
   static void ReportInputSignatureChanges(JsonWriter* msg, NodeState* node, const NodeData* node_data, const NodeStateData* prev_state, StatCache* stat_cache, DigestCache* digest_cache, ScanCache* scan_cache, const uint32_t sha_extension_hashes[], int sha_extension_hash_count, ThreadState* thread_state)
   {
     if (strcmp(node_data->m_Action, prev_state->m_Action) != 0)
@@ -331,11 +344,8 @@ namespace t2
       JsonWriteKeyName(msg, "key");
       JsonWriteValueString(msg, "Action");
 
-      JsonWriteKeyName(msg, "value");
-      JsonWriteValueString(msg, node_data->m_Action);
-
-      JsonWriteKeyName(msg, "oldvalue");
-      JsonWriteValueString(msg, prev_state->m_Action);
+      ReportValueWithOptionalTruncation(msg, "value", "value_truncated", node_data->m_Action);
+      ReportValueWithOptionalTruncation(msg, "oldvalue", "oldvalue_truncated", prev_state->m_Action);
 
       JsonWriteEndObject(msg);
     }
@@ -349,11 +359,8 @@ namespace t2
         JsonWriteKeyName(msg, "key");
         JsonWriteValueString(msg, "PreAction");
 
-        JsonWriteKeyName(msg, "value");
-        JsonWriteValueString(msg, node_data->m_PreAction);
-
-        JsonWriteKeyName(msg, "oldvalue");
-        JsonWriteValueString(msg, prev_state->m_PreAction);
+        ReportValueWithOptionalTruncation(msg, "value", "value_truncated", node_data->m_PreAction);
+        ReportValueWithOptionalTruncation(msg, "oldvalue", "oldvalue_truncated", prev_state->m_PreAction);
 
         JsonWriteEndObject(msg);
       }

--- a/src/JsonWriter.cpp
+++ b/src/JsonWriter.cpp
@@ -89,14 +89,15 @@ void JsonWriteKeyName(JsonWriter* writer, const char* keyName)
     writer->m_PrependComma = false;
 }
 
-void JsonWriteValueString(JsonWriter* writer, const char* value)
+void JsonWriteValueString(JsonWriter* writer, const char* value, size_t maxLen)
 {
     if (writer->m_PrependComma)
       JsonWriteChar(writer, ',');
 
     JsonWriteChar(writer, '"');
 
-    while (*value != 0)
+    size_t len = 0;
+    while (*value != 0 && len < maxLen)
     {
         char ch = *(value++);
         if (ch == '"')
@@ -131,6 +132,7 @@ void JsonWriteValueString(JsonWriter* writer, const char* value)
         {
             JsonWriteChar(writer, ch);
         }
+        ++len;
     }
 
     JsonWriteChar(writer, '"');

--- a/src/JsonWriter.hpp
+++ b/src/JsonWriter.hpp
@@ -30,7 +30,7 @@ void JsonWriteEndArray(JsonWriter* writer);
 
 void JsonWriteKeyName(JsonWriter* writer, const char* keyName);
 
-void JsonWriteValueString(JsonWriter* writer, const char* value);
+void JsonWriteValueString(JsonWriter* writer, const char* value, size_t maxLen = (size_t)-1);
 void JsonWriteValueInteger(JsonWriter* writer, int64_t value);
 
 void JsonWriteToFile(JsonWriter* writer, FILE* fp);


### PR DESCRIPTION
The "structured log" output was crashing with out of memory if some action strings got really large (like WriteText for a giant project file -- we have AllTargets.xcodeproj that reaches 16MB). They are all using temporary scratch arena allocator, and that one is 32MB capacity. Encoding previous + current strings would run out of memory there.

Now in the structured log, "value" strings are truncated to 64kb length. When truncation happens, it emits additional `"value_truncated": 1` or `"oldvalue_truncated": 1` fields.