### PR TITLE
Add profiling for CheckInputSignature

### DIFF
--- a/src/BuildQueue.cpp
+++ b/src/BuildQueue.cpp
@@ -523,6 +523,8 @@ namespace t2
 
     MutexUnlock(queue_lock);
 
+    ProfilerScope prof_scope("Tundra CheckInputSignature", thread_state->m_ThreadIndex);
+
     const BuildQueueConfig& config = queue->m_Config;
     StatCache* stat_cache = config.m_StatCache;
     DigestCache* digest_cache = config.m_DigestCache;


### PR DESCRIPTION
There's a big block of unaccounted-for build time in zero-change builds for large DAGs. Code inspection, and profiling with the VS profiler, revealed that it's primarily the call tree under CheckInputSignature - stat64() calls for most files, plus some file hashing. By adding a profiler scope to CheckInputSignature, we account for most of the unaccounted-for time.