### PR TITLE
Cleaner output on errors

### DIFF
--- a/src/BuildQueue.cpp
+++ b/src/BuildQueue.cpp
@@ -1292,6 +1292,11 @@ namespace t2
       ThreadStateDestroy(&queue->m_ThreadState[i]);
     }
 
+    // Output any deferred error messages.
+    MutexLock(&queue->m_Lock);
+    PrintDeferredMessages(queue);
+    MutexUnlock(&queue->m_Lock);
+
     // Deallocate storage.
     MemAllocHeap* heap = queue->m_Config.m_Heap;
     HeapFree(heap, queue->m_ExpensiveWaitList);

--- a/src/BuildQueue.cpp
+++ b/src/BuildQueue.cpp
@@ -1139,6 +1139,18 @@ namespace t2
     return state;
   }
 
+  bool HasBuildStoppingFailures(const BuildQueue* queue)
+  {
+    if (queue->m_FailedNodeCount > 0)
+    {
+      if (0 == (queue->m_Config.m_Flags & BuildQueueConfig::kFlagContinueOnError))
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+
   static bool ShouldKeepBuilding(BuildQueue* queue, int thread_index)
   {
     // Stop running if we were signalled
@@ -1146,13 +1158,8 @@ namespace t2
       return false;
 
     // Stop running if there are errors and we're stopping on the first error.
-    if (queue->m_FailedNodeCount > 0)
-    {
-      if (0 == (queue->m_Config.m_Flags & BuildQueueConfig::kFlagContinueOnError))
-      {
-        return false;
-      }
-    }
+    if (HasBuildStoppingFailures(queue))
+      return false;
 
     // If we're quitting, definitely stop building.
     if (queue->m_QuitSignalled)

--- a/src/BuildQueue.hpp
+++ b/src/BuildQueue.hpp
@@ -103,6 +103,8 @@ namespace t2
 
   void BuildQueueDestroy(BuildQueue* queue);
 
+  bool HasBuildStoppingFailures(const BuildQueue* queue);
+
 }
 
 #endif

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -252,7 +252,7 @@ static bool DriverPrepareDag(Driver* self, const char* dag_fn)
     uint64_t now = TimerGet();
     int duration = TimerDiffSeconds(time_exec_started, now);
     if (duration > 1)
-      PrintLineWithDurationAndAnnotation(time_exec_started, 0, 0, MessageStatusLevel::Warning, "Calculating file and glob signatures. (unusually slow)");
+      PrintLineWithDurationAndAnnotation(duration, 0, 0, MessageStatusLevel::Warning, "Calculating file and glob signatures. (unusually slow)");
 
     if (checkResult)
     {
@@ -269,7 +269,7 @@ static bool DriverPrepareDag(Driver* self, const char* dag_fn)
   if (!GenerateDag(s_BuildFile, dag_fn))
     return false;
 
-  PrintLineWithDurationAndAnnotation(time_exec_started, 0, 0, MessageStatusLevel::Success, out_of_date_reason);
+  PrintLineWithDurationAndAnnotation(TimerDiffSeconds(time_exec_started, TimerGet()), 0, 0, MessageStatusLevel::Success, out_of_date_reason);
 
   // The DAG had better map in now, or we can give up.
   if (!LoadFrozenData<DagData>(dag_fn, &self->m_DagFile, &self->m_DagData))

--- a/src/NodeResultPrinting.cpp
+++ b/src/NodeResultPrinting.cpp
@@ -223,8 +223,12 @@ void PrintLineWithDurationAndAnnotation(uint64_t time_exec_started, int nodeCoun
       printf("!FAILED! ");
     printf("%*d/%d ", maxDigits, nodeCount, max_nodes);
     printf("%2ds] ", duration);
-    EmitColor(RESET); 
-    printf("%s\n", annotation);   
+    // for failures, color the whole line red and only reset at the end
+    if (status_level != MessageStatusLevel::Failure)
+      EmitColor(RESET); 
+    printf("%s\n", annotation);
+    if (status_level == MessageStatusLevel::Failure)
+      EmitColor(RESET);
 }
 
 void PrintNodeResult(

--- a/src/NodeResultPrinting.cpp
+++ b/src/NodeResultPrinting.cpp
@@ -235,11 +235,16 @@ void PrintNodeResult(
   bool always_verbose,
   uint64_t time_exec_started,
   ValidationResult validationResult,
-  bool* untouched_outputs)
+  const bool* untouched_outputs)
 {
     int processedNodeCount = ++queue->m_ProcessedNodeCount;
     bool failed = result->m_ReturnCode != 0 || result->m_WasSignalled || validationResult >= ValidationResult::UnexpectedConsoleOutputFail;
     bool verbose = (failed && !result->m_WasAborted) || always_verbose;
+
+    // If we already had build failures that will stop the build: do not emit further successful build step outputs.
+    // Makes it so that the failure is at the end of the build log.
+    if (!failed && !verbose && HasBuildStoppingFailures(queue))
+      return;
 
     PrintLineWithDurationAndAnnotation(time_exec_started, processedNodeCount, queue->m_Config.m_MaxNodes, failed ? MessageStatusLevel::Failure : MessageStatusLevel::Success, node_data->m_Annotation.Get());
 

--- a/src/NodeResultPrinting.cpp
+++ b/src/NodeResultPrinting.cpp
@@ -15,11 +15,31 @@
 namespace t2
 {
 
+struct NodeResultPrintData
+{
+  const NodeData* node_data;
+  const char* cmd_line;
+  bool verbose;
+  int duration;
+  ValidationResult validation_result;
+  const bool* untouched_outputs;
+  const char* output_buffer;
+  int processed_node_count;
+  MessageStatusLevel::Enum status_level;
+  int return_code;
+  bool was_signalled;
+  bool was_aborted;
+};
+
+
 static bool EmitColors = false;
 
 static uint64_t last_progress_message_of_any_job;
 static const NodeData* last_progress_message_job = nullptr;
 static int total_number_node_results_printed = 0;
+
+static int deferred_message_count = 0;
+static NodeResultPrintData deferred_messages[kMaxBuildThreads];
 
 
 static bool isTerminatingChar(char c)
@@ -190,7 +210,7 @@ void PrintServiceMessage(MessageStatusLevel::Enum status_level, const char* form
     printf("\n");
 }
 
-static void PrintBufferTrimmed(OutputBufferData* buffer)
+static void TrimOutputBuffer(OutputBufferData* buffer)
 {
   auto isNewLine = [](char c) {return c == 0x0A || c == 0x0D; };
 
@@ -198,24 +218,17 @@ static void PrintBufferTrimmed(OutputBufferData* buffer)
   while (isNewLine(*(buffer->buffer + trimmedCursor -1)) && trimmedCursor > 0)
     trimmedCursor--;
 
-  if (EmitColors)
+  buffer->buffer[trimmedCursor] = 0;
+  if (!EmitColors)
   {
-    fwrite(buffer->buffer, 1, trimmedCursor, stdout);
-  } else {
-    buffer->buffer[trimmedCursor] = 0;
     StripAnsiColors(buffer->buffer);
-    fwrite(buffer->buffer, 1, strlen(buffer->buffer), stdout);
   }
-  printf("\n");
 }
 
-void PrintLineWithDurationAndAnnotation(uint64_t time_exec_started, int nodeCount, int max_nodes, MessageStatusLevel::Enum status_level, const char* annotation)
+void PrintLineWithDurationAndAnnotation(int duration, int nodeCount, int max_nodes, MessageStatusLevel::Enum status_level, const char* annotation)
 {
     int maxDigits = ceil(log10(max_nodes+1)); 
 
-    uint64_t now = TimerGet();
-    int duration = TimerDiffSeconds(time_exec_started, now);
-    
     EmitColorForLevel(status_level);
 
     printf("[");
@@ -231,34 +244,17 @@ void PrintLineWithDurationAndAnnotation(uint64_t time_exec_started, int nodeCoun
       EmitColor(RESET);
 }
 
-void PrintNodeResult(
-  ExecResult* result,
-  const NodeData* node_data,
-  const char* cmd_line,
-  BuildQueue* queue,
-  bool always_verbose,
-  uint64_t time_exec_started,
-  ValidationResult validationResult,
-  const bool* untouched_outputs)
+static void PrintNodeResult(const NodeResultPrintData* data, BuildQueue* queue)
 {
-    int processedNodeCount = ++queue->m_ProcessedNodeCount;
-    bool failed = result->m_ReturnCode != 0 || result->m_WasSignalled || validationResult >= ValidationResult::UnexpectedConsoleOutputFail;
-    bool verbose = (failed && !result->m_WasAborted) || always_verbose;
+    PrintLineWithDurationAndAnnotation(data->duration, data->processed_node_count, queue->m_Config.m_MaxNodes, data->status_level, data->node_data->m_Annotation.Get());
 
-    // If we already had build failures that will stop the build: do not emit further successful build step outputs.
-    // Makes it so that the failure is at the end of the build log.
-    if (!failed && !verbose && HasBuildStoppingFailures(queue))
-      return;
-
-    PrintLineWithDurationAndAnnotation(time_exec_started, processedNodeCount, queue->m_Config.m_MaxNodes, failed ? MessageStatusLevel::Failure : MessageStatusLevel::Success, node_data->m_Annotation.Get());
-
-    if (verbose)
+    if (data->verbose)
     {
-        PrintDiagnostic("CommandLine", cmd_line);
-        for (int i=0; i!= node_data->m_FrontendResponseFiles.GetCount(); i++)
+        PrintDiagnostic("CommandLine", data->cmd_line);
+        for (int i=0; i!= data->node_data->m_FrontendResponseFiles.GetCount(); i++)
         {
             char titleBuffer[1024];
-            const char* file = node_data->m_FrontendResponseFiles[i].m_Filename;
+            const char* file = data->node_data->m_FrontendResponseFiles[i].m_Filename;
             snprintf(titleBuffer, sizeof titleBuffer, "Contents of %s", file);
 
             char* content_buffer;
@@ -285,55 +281,158 @@ void PrintNodeResult(
         }
 
 
-        if (node_data->m_EnvVars.GetCount() > 0)
+        if (data->node_data->m_EnvVars.GetCount() > 0)
           PrintDiagnosticPrefix("Custom Environment Variables");
-        for (int i=0; i!=node_data->m_EnvVars.GetCount(); i++)
+        for (int i=0; i!= data->node_data->m_EnvVars.GetCount(); i++)
         {
-           auto& entry = node_data->m_EnvVars[i];
+           auto& entry = data->node_data->m_EnvVars[i];
            printf("%s=%s\n", entry.m_Name.Get(), entry.m_Value.Get() );
         }
-        if (result->m_ReturnCode == 0 && !result->m_WasSignalled)
+        if (data->return_code == 0 && !data->was_signalled)
         {
-          if (validationResult == ValidationResult::UnexpectedConsoleOutputFail)
+          if (data->validation_result == ValidationResult::UnexpectedConsoleOutputFail)
           {
             PrintDiagnosticPrefix("Failed because this command wrote something to the output that wasn't expected. We were expecting any of the following strings:", RED);
-            int count = node_data->m_AllowedOutputSubstrings.GetCount();
+            int count = data->node_data->m_AllowedOutputSubstrings.GetCount();
             for (int i = 0; i != count; i++)
-              printf("%s\n", (const char*)node_data->m_AllowedOutputSubstrings[i]);
+              printf("%s\n", (const char*)data->node_data->m_AllowedOutputSubstrings[i]);
             if (count == 0)
               printf("<< no allowed strings >>\n");
           }
-          else if (validationResult == ValidationResult::UnwrittenOutputFileFail)
+          else if (data->validation_result == ValidationResult::UnwrittenOutputFileFail)
           {
             PrintDiagnosticPrefix("Failed because this command failed to write the following output files:", RED);
-            for (int i = 0; i < node_data->m_OutputFiles.GetCount(); i++)
-              if (untouched_outputs[i])
-                printf("%s\n", (const char*)node_data->m_OutputFiles[i].m_Filename);
+            for (int i = 0; i < data->node_data->m_OutputFiles.GetCount(); i++)
+              if (data->untouched_outputs[i])
+                printf("%s\n", (const char*)data->node_data->m_OutputFiles[i].m_Filename);
           }
         }
-        if (result->m_WasSignalled)
+        if (data->was_signalled)
           PrintDiagnostic("Was Signaled", "Yes");
-        if (result->m_WasAborted)
+        if (data->was_aborted)
           PrintDiagnostic("Was Aborted", "Yes");
-        if (result->m_ReturnCode !=0)
-          PrintDiagnostic("ExitCode", result->m_ReturnCode);
+        if (data->return_code !=0)
+          PrintDiagnostic("ExitCode", data->return_code);
     }
 
-    bool anyOutput = result->m_OutputBuffer.cursor>0;
-
-    if (anyOutput && verbose)
+    if (data->output_buffer != nullptr)
     {
-      PrintDiagnosticPrefix("Output");
-      PrintBufferTrimmed(&result->m_OutputBuffer);
-    } else if (anyOutput && 0 != (validationResult != ValidationResult::SwallowStdout))
-        PrintBufferTrimmed(&result->m_OutputBuffer);
-    
-    total_number_node_results_printed++;
-    last_progress_message_of_any_job = TimerGet();
-    last_progress_message_job = node_data;
-
-    fflush(stdout);
+      if (data->verbose)
+      {
+        PrintDiagnosticPrefix("Output");
+        printf("%s\n", data->output_buffer);
+      }
+      else if (0 != (data->validation_result != ValidationResult::SwallowStdout))
+      {
+        printf("%s\n", data->output_buffer);
+      }
+    }
 }
+
+inline char* StrDupN(MemAllocHeap* allocator, const char* str, size_t len)
+{
+  size_t sz = len + 1;
+  char* buffer = static_cast<char*>(HeapAllocate(allocator, sz));
+  memcpy(buffer, str, sz - 1);
+  buffer[sz - 1] = '\0';
+  return buffer;
+}
+
+inline char* StrDup(MemAllocHeap* allocator, const char* str)
+{
+  return StrDupN(allocator, str, strlen(str));
+}
+
+
+void PrintNodeResult(
+  ExecResult* result,
+  const NodeData* node_data,
+  const char* cmd_line,
+  BuildQueue* queue,
+  bool always_verbose,
+  uint64_t time_exec_started,
+  ValidationResult validationResult,
+  const bool* untouched_outputs)
+{
+  int processedNodeCount = ++queue->m_ProcessedNodeCount;
+  bool failed = result->m_ReturnCode != 0 || result->m_WasSignalled || validationResult >= ValidationResult::UnexpectedConsoleOutputFail;
+  bool verbose = (failed && !result->m_WasAborted) || always_verbose;
+
+  int duration = TimerDiffSeconds(time_exec_started, TimerGet());
+
+  NodeResultPrintData data = {};
+  data.node_data = node_data;
+  data.cmd_line = cmd_line;
+  data.verbose = verbose;
+  data.duration = duration;
+  data.validation_result = validationResult;
+  data.untouched_outputs = untouched_outputs;
+  data.processed_node_count = processedNodeCount;
+  data.status_level = failed ? MessageStatusLevel::Failure : MessageStatusLevel::Success;
+  data.return_code = result->m_ReturnCode;
+  data.was_signalled = result->m_WasSignalled;
+  data.was_aborted = result->m_WasAborted;
+
+  bool anyOutput = result->m_OutputBuffer.cursor > 0;
+  if (anyOutput && verbose)
+  {
+    TrimOutputBuffer(&result->m_OutputBuffer);
+    data.output_buffer = result->m_OutputBuffer.buffer;
+  }
+  else if (anyOutput && 0 != (validationResult != ValidationResult::SwallowStdout))
+  {
+    TrimOutputBuffer(&result->m_OutputBuffer);
+    data.output_buffer = result->m_OutputBuffer.buffer;
+  }
+
+  // defer most of regular build failure output to the end of build, so that they are all
+  // conveniently at the end of the log
+  bool defer = failed && (0 == (queue->m_Config.m_Flags & BuildQueueConfig::kFlagContinueOnError)) && deferred_message_count < ARRAY_SIZE(deferred_messages);
+  if (!defer)
+  {
+    PrintNodeResult(&data, queue);
+  }
+  else
+  {
+    // copy data needed for output that might be coming from temporary/local storage
+    data.cmd_line = StrDup(queue->m_Config.m_Heap, data.cmd_line);
+    if (data.output_buffer != nullptr)
+      data.output_buffer = StrDup(queue->m_Config.m_Heap, data.output_buffer);
+    int n_outputs = node_data->m_OutputFiles.GetCount();
+    bool* untouched_outputs_copy = (bool*)HeapAllocate(queue->m_Config.m_Heap, n_outputs * sizeof(bool));
+    memcpy(untouched_outputs_copy, untouched_outputs, n_outputs * sizeof(bool));
+    data.untouched_outputs = untouched_outputs_copy;
+
+    // store data needed for deferred output
+    deferred_messages[deferred_message_count] = data;
+    deferred_message_count++;
+  }
+
+  total_number_node_results_printed++;
+  last_progress_message_of_any_job = TimerGet();
+  last_progress_message_job = node_data;
+
+  fflush(stdout);
+}
+
+void PrintDeferredMessages(BuildQueue* queue)
+{
+  for (int i = 0; i < deferred_message_count; ++i)
+  {
+    const NodeResultPrintData& data = deferred_messages[i];
+    PrintNodeResult(&data, queue);
+    if (data.cmd_line != nullptr)
+      HeapFree(queue->m_Config.m_Heap, data.cmd_line);
+    if (data.output_buffer != nullptr)
+      HeapFree(queue->m_Config.m_Heap, data.output_buffer);
+    if (data.untouched_outputs != nullptr)
+      HeapFree(queue->m_Config.m_Heap, data.untouched_outputs);
+  }
+  fflush(stdout);
+  deferred_message_count = 0;
+}
+
+
 
 int PrintNodeInProgress(const NodeData* node_data, uint64_t time_of_start, const BuildQueue* queue)
 {
@@ -351,7 +450,7 @@ int PrintNodeInProgress(const NodeData* node_data, uint64_t time_of_start, const
     EmitColor(YEL);
     printf("[BUSY %*ds] ", maxDigits*2-1, seconds_job_has_been_running_for);
     EmitColor(RESET);
-    printf("%s\n", (const char*)node_data->m_Annotation);
+    printf("%s\n", HasBuildStoppingFailures(queue) ? "...waiting for other build steps to finish" : (const char*)node_data->m_Annotation);
     last_progress_message_of_any_job = now;
     last_progress_message_job = node_data;
 

--- a/src/NodeResultPrinting.cpp
+++ b/src/NodeResultPrinting.cpp
@@ -450,7 +450,7 @@ int PrintNodeInProgress(const NodeData* node_data, uint64_t time_of_start, const
     EmitColor(YEL);
     printf("[BUSY %*ds] ", maxDigits*2-1, seconds_job_has_been_running_for);
     EmitColor(RESET);
-    printf("%s\n", HasBuildStoppingFailures(queue) ? "...waiting for other build steps to finish" : (const char*)node_data->m_Annotation);
+    printf("%s\n", (const char*)node_data->m_Annotation);
     last_progress_message_of_any_job = now;
     last_progress_message_job = node_data;
 

--- a/src/NodeResultPrinting.hpp
+++ b/src/NodeResultPrinting.hpp
@@ -32,7 +32,8 @@ void PrintNodeResult(
   ValidationResult validationResult,
   const bool* untouched_outputs);
 int PrintNodeInProgress(const NodeData* node_data, uint64_t time_of_start, const BuildQueue* queue);
-void PrintLineWithDurationAndAnnotation(uint64_t time_exec_started, int nodeCount, int max_nodes, MessageStatusLevel::Enum status_level, const char* annotation);
+void PrintDeferredMessages(BuildQueue* queue);
+void PrintLineWithDurationAndAnnotation(int duration, int nodeCount, int max_nodes, MessageStatusLevel::Enum status_level, const char* annotation);
 void PrintServiceMessage(MessageStatusLevel::Enum statusLevel, const char* formatString, ...);
 void StripAnsiColors(char* buffer);
 }

--- a/src/NodeResultPrinting.hpp
+++ b/src/NodeResultPrinting.hpp
@@ -30,7 +30,7 @@ void PrintNodeResult(
   bool always_verbose,
   uint64_t time_exec_started,
   ValidationResult validationResult,
-  bool* untouched_outputs);
+  const bool* untouched_outputs);
 int PrintNodeInProgress(const NodeData* node_data, uint64_t time_of_start, const BuildQueue* queue);
 void PrintLineWithDurationAndAnnotation(uint64_t time_exec_started, int nodeCount, int max_nodes, MessageStatusLevel::Enum status_level, const char* annotation);
 void PrintServiceMessage(MessageStatusLevel::Enum statusLevel, const char* formatString, ...);


### PR DESCRIPTION
Make failed build steps more visible. Apparently a bunch of people can't find "what exactly has failed", especially on many-core machines where the failure message might have already scrolled by.

- Defer error step outputs to the end of the whole log.
- For failed steps, make the whole output line red, instead of just the step number/time part.

Before:
![tundra1a](https://user-images.githubusercontent.com/348087/45801652-22979380-bcbd-11e8-8086-0f69c7530611.png)

After:
![tundra4](https://user-images.githubusercontent.com/348087/45811183-17506200-bcd5-11e8-88d8-c7b4be0a67c2.png)

