### PR TITLE
Shared Resources support

### DIFF
--- a/src/BuildQueue.cpp
+++ b/src/BuildQueue.cpp
@@ -864,7 +864,14 @@ namespace t2
     }
 
     for (int i = 0; i < node_data->m_SharedResources.GetCount(); ++i)
-      SharedResourceAcquire(queue, &thread_state->m_LocalHeap, node_data->m_SharedResources[i]);
+    {
+      if (!SharedResourceAcquire(queue, &thread_state->m_LocalHeap, node_data->m_SharedResources[i]))
+      {
+        Log(kError, "failed to create shared resource %s", queue->m_Config.m_SharedResources[node_data->m_SharedResources[i]].m_Annotation.Get());
+        MutexLock(queue_lock);
+        return BuildProgress::kFailed;
+      }
+    }
 
     auto EnsureParentDirExistsFor = [=](const FrozenFileAndHash& fileAndHash) -> bool {
         PathBuffer output;

--- a/src/BuildQueue.cpp
+++ b/src/BuildQueue.cpp
@@ -17,6 +17,7 @@
 #include "NodeResultPrinting.hpp"
 #include "OutputValidation.hpp"
 #include "DigestCache.hpp"
+#include "SharedResources.hpp"
 
 #include <stdio.h>
 
@@ -862,6 +863,9 @@ namespace t2
       env_vars[i].m_Value = node_data->m_EnvVars[i].m_Value;
     }
 
+    for (int i = 0; i < node_data->m_SharedResources.GetCount(); ++i)
+      SharedResourceAcquire(queue, &thread_state->m_LocalHeap, node_data->m_SharedResources[i]);
+
     auto EnsureParentDirExistsFor = [=](const FrozenFileAndHash& fileAndHash) -> bool {
         PathBuffer output;
         PathInit(&output, fileAndHash.m_Filename);
@@ -1237,6 +1241,8 @@ namespace t2
     queue->m_ExpensiveRunning   = 0;
     queue->m_ExpensiveWaitCount = 0;
     queue->m_ExpensiveWaitList  = HeapAllocateArray<NodeState*>(heap, capacity);
+    queue->m_SharedResourcesCreated = HeapAllocateArrayZeroed<uint32_t>(heap, config->m_SharedResourcesCount);
+    MutexInit(&queue->m_SharedResourcesLock);
 
     CHECK(queue->m_Queue);
 
@@ -1292,6 +1298,11 @@ namespace t2
       ThreadStateDestroy(&queue->m_ThreadState[i]);
     }
 
+    // Destroy any shared resources that were created
+    for (int i = 0; i < config->m_SharedResourcesCount; ++i)
+      if (queue->m_SharedResourcesCreated[i] > 0)
+        SharedResourceDestroy(queue, config->m_Heap, i);
+
     // Output any deferred error messages.
     MutexLock(&queue->m_Lock);
     PrintDeferredMessages(queue);
@@ -1301,6 +1312,8 @@ namespace t2
     MemAllocHeap* heap = queue->m_Config.m_Heap;
     HeapFree(heap, queue->m_ExpensiveWaitList);
     HeapFree(heap, queue->m_Queue);
+    HeapFree(heap, queue->m_SharedResourcesCreated);
+    MutexDestroy(&queue->m_SharedResourcesLock);
 
     CondDestroy(&queue->m_WorkAvailable);
     MutexDestroy(&queue->m_Lock);

--- a/src/BuildQueue.hpp
+++ b/src/BuildQueue.hpp
@@ -8,6 +8,7 @@
 #include "MemAllocLinear.hpp"
 #include "MemAllocHeap.hpp"
 #include "JsonWriter.hpp"
+#include "DagData.hpp"
 
 namespace t2
 {
@@ -50,6 +51,8 @@ namespace t2
     void*           m_FileSigningLog;
     Mutex*          m_FileSigningLogMutex;
     int32_t         m_MaxExpensiveCount;
+    const SharedResourceData* m_SharedResources;
+    int             m_SharedResourcesCount;
   };
 
   struct BuildQueue;
@@ -80,6 +83,8 @@ namespace t2
     int32_t            m_ExpensiveRunning;
     int32_t            m_ExpensiveWaitCount;
     NodeState        **m_ExpensiveWaitList;
+    uint32_t          *m_SharedResourcesCreated;
+    Mutex              m_SharedResourcesLock;
     bool               m_QuitSignalled;
   };
 

--- a/src/DagData.hpp
+++ b/src/DagData.hpp
@@ -121,6 +121,7 @@ struct NodeData
   FrozenArray<FrozenString>       m_AllowedOutputSubstrings;
   FrozenArray<EnvVarData>         m_EnvVars;
   FrozenPtr<ScannerData>          m_Scanner;
+  FrozenArray<int32_t>            m_SharedResources;
   uint32_t                        m_Flags;
   uint32_t                        m_OriginalIndex;
 };
@@ -128,6 +129,14 @@ struct NodeData
 struct PassData
 {
   FrozenString m_PassName;
+};
+
+struct SharedResourceData
+{
+  FrozenString m_Annotation;
+  FrozenString m_CreateAction;
+  FrozenString m_DestroyAction;
+  FrozenArray<EnvVarData> m_EnvVars;
 };
 
 struct DagData
@@ -143,6 +152,8 @@ struct DagData
   FrozenPtr<NodeData>           m_NodeData;
 
   FrozenArray<PassData>         m_Passes;
+
+  FrozenArray<SharedResourceData> m_SharedResources;
 
   int32_t                       m_ConfigCount;
   FrozenPtr<FrozenString>       m_ConfigNames;

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -825,6 +825,8 @@ BuildResult::Enum DriverBuild(Driver* self)
   queue_config.m_ShaDigestExtensionCount = dag->m_ShaExtensionHashes.GetCount();
   queue_config.m_ShaDigestExtensions     = dag->m_ShaExtensionHashes.GetArray();
   queue_config.m_MaxExpensiveCount       = max_expensive_count;
+  queue_config.m_SharedResources         = dag->m_SharedResources.GetArray();
+  queue_config.m_SharedResourcesCount    = dag->m_SharedResources.GetCount();
 
   if (self->m_Options.m_Verbose)
   {

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -252,7 +252,7 @@ static bool DriverPrepareDag(Driver* self, const char* dag_fn)
     uint64_t now = TimerGet();
     int duration = TimerDiffSeconds(time_exec_started, now);
     if (duration > 1)
-      PrintLineWithDurationAndAnnotation(duration, 0, 0, MessageStatusLevel::Warning, "Calculating file and glob signatures. (unusually slow)");
+      PrintNonNodeActionResult(duration, self->m_DagData->m_NodeCount, MessageStatusLevel::Warning, "Calculating file and glob signatures. (unusually slow)");
 
     if (checkResult)
     {
@@ -269,7 +269,7 @@ static bool DriverPrepareDag(Driver* self, const char* dag_fn)
   if (!GenerateDag(s_BuildFile, dag_fn))
     return false;
 
-  PrintLineWithDurationAndAnnotation(TimerDiffSeconds(time_exec_started, TimerGet()), 0, 0, MessageStatusLevel::Success, out_of_date_reason);
+  PrintNonNodeActionResult(TimerDiffSeconds(time_exec_started, TimerGet()), 1, MessageStatusLevel::Success, out_of_date_reason);
 
   // The DAG had better map in now, or we can give up.
   if (!LoadFrozenData<DagData>(dag_fn, &self->m_DagFile, &self->m_DagData))

--- a/src/NodeResultPrinting.hpp
+++ b/src/NodeResultPrinting.hpp
@@ -33,7 +33,7 @@ void PrintNodeResult(
   const bool* untouched_outputs);
 int PrintNodeInProgress(const NodeData* node_data, uint64_t time_of_start, const BuildQueue* queue);
 void PrintDeferredMessages(BuildQueue* queue);
-void PrintLineWithDurationAndAnnotation(int duration, int nodeCount, int max_nodes, MessageStatusLevel::Enum status_level, const char* annotation);
+void PrintNonNodeActionResult(int duration, int max_nodes, MessageStatusLevel::Enum status_level, const char* annotation, ExecResult* result = nullptr);
 void PrintServiceMessage(MessageStatusLevel::Enum statusLevel, const char* formatString, ...);
 void StripAnsiColors(char* buffer);
 }

--- a/src/SharedResources.cpp
+++ b/src/SharedResources.cpp
@@ -1,0 +1,60 @@
+#include "SharedResources.hpp"
+#include "Common.hpp"
+#include "Exec.hpp"
+#include "NodeResultPrinting.hpp"
+#include "Mutex.hpp"
+#include "Atomic.hpp"
+#include "BuildQueue.hpp"
+
+namespace t2
+{
+  static void SharedResourceExecute(const SharedResourceData* sharedResource, const char* action, const char* formatString, MemAllocHeap* heap, int maxNodes)
+  {
+    const int fullAnnotationLength = strlen(sharedResource->m_Annotation) + 20;
+    char* fullAnnotation = (char*)alloca(fullAnnotationLength);
+    snprintf(fullAnnotation, fullAnnotationLength, formatString, sharedResource->m_Annotation.Get());
+
+    const int envVarsCount = sharedResource->m_EnvVars.GetCount();
+    EnvVariable* envVars = (EnvVariable*)alloca(envVarsCount * sizeof(EnvVariable));
+    for (int i = 0; i < envVarsCount; ++i)
+    {
+      envVars[i].m_Name = sharedResource->m_EnvVars[i].m_Name;
+      envVars[i].m_Value = sharedResource->m_EnvVars[i].m_Value;
+    }
+
+    uint64_t time_exec_started = TimerGet();
+    ExecResult result = ExecuteProcess(action, envVarsCount, envVars, heap, 0, false);
+    PrintNonNodeActionResult(TimerDiffSeconds(time_exec_started, TimerGet()), maxNodes, result.m_ReturnCode == 0 ? MessageStatusLevel::Success : MessageStatusLevel::Failure, fullAnnotation, &result);
+  }
+
+  static void SharedResourceCreate(const SharedResourceData* sharedResource, MemAllocHeap* heap, int maxNodes)
+  {
+    if (sharedResource->m_CreateAction != nullptr)
+      SharedResourceExecute(sharedResource, sharedResource->m_CreateAction, "Creating %s", heap, maxNodes);
+  }
+
+  void SharedResourceAcquire(BuildQueue* queue, MemAllocHeap* heap, uint32_t sharedResourceIndex)
+  {
+    uint32_t& refVar = queue->m_SharedResourcesCreated[sharedResourceIndex];
+
+    if (refVar == 0)
+    {
+      MutexLock(&queue->m_SharedResourcesLock);
+      // Check that another thread didn't start this resource while we were waiting for the lock
+      if (refVar == 0)
+      {
+        SharedResourceCreate(&queue->m_Config.m_SharedResources[sharedResourceIndex], heap, queue->m_Config.m_MaxNodes);
+        AtomicIncrement(&refVar);
+      }
+      MutexUnlock(&queue->m_SharedResourcesLock);
+    }
+  }
+
+  void SharedResourceDestroy(BuildQueue* queue, MemAllocHeap* heap, uint32_t sharedResourceIndex)
+  {
+    const SharedResourceData* sharedResource = &queue->m_Config.m_SharedResources[sharedResourceIndex];
+    if (sharedResource->m_DestroyAction != nullptr)
+      SharedResourceExecute(sharedResource, sharedResource->m_DestroyAction, "Destroying %s", heap, queue->m_Config.m_MaxNodes);
+    queue->m_SharedResourcesCreated[sharedResourceIndex] = 0;
+  }
+}

--- a/src/SharedResources.hpp
+++ b/src/SharedResources.hpp
@@ -1,0 +1,11 @@
+#include <cstdint>
+
+namespace t2
+{
+  struct MemAllocHeap;
+  struct SharedResourceData;
+  struct BuildQueue;
+
+  void SharedResourceAcquire(BuildQueue* queue, MemAllocHeap* heap, uint32_t sharedResourceIndex);
+  void SharedResourceDestroy(BuildQueue* queue, MemAllocHeap* heap, uint32_t sharedResourceIndex);
+}

--- a/src/SharedResources.hpp
+++ b/src/SharedResources.hpp
@@ -6,6 +6,6 @@ namespace t2
   struct SharedResourceData;
   struct BuildQueue;
 
-  void SharedResourceAcquire(BuildQueue* queue, MemAllocHeap* heap, uint32_t sharedResourceIndex);
+  bool SharedResourceAcquire(BuildQueue* queue, MemAllocHeap* heap, uint32_t sharedResourceIndex);
   void SharedResourceDestroy(BuildQueue* queue, MemAllocHeap* heap, uint32_t sharedResourceIndex);
 }

--- a/vs2017/libtundra/libtundra.vcxproj
+++ b/vs2017/libtundra/libtundra.vcxproj
@@ -114,6 +114,7 @@
     <ClInclude Include="..\..\src\ScanCache.hpp" />
     <ClInclude Include="..\..\src\ScanData.hpp" />
     <ClInclude Include="..\..\src\Scanner.hpp" />
+    <ClInclude Include="..\..\src\SharedResources.hpp" />
     <ClInclude Include="..\..\src\SignalHandler.hpp" />
     <ClInclude Include="..\..\src\SortedArrayUtil.hpp" />
     <ClInclude Include="..\..\src\StatCache.hpp" />
@@ -155,6 +156,7 @@
     <ClCompile Include="..\..\src\ReadWriteLock.cpp" />
     <ClCompile Include="..\..\src\ScanCache.cpp" />
     <ClCompile Include="..\..\src\Scanner.cpp" />
+    <ClCompile Include="..\..\src\SharedResources.cpp" />
     <ClCompile Include="..\..\src\SignalHandler.cpp" />
     <ClCompile Include="..\..\src\StatCache.cpp" />
     <ClCompile Include="..\..\src\TargetSelect.cpp" />

--- a/vs2017/libtundra/libtundra.vcxproj.filters
+++ b/vs2017/libtundra/libtundra.vcxproj.filters
@@ -129,7 +129,10 @@
     <ClInclude Include="..\..\src\Profiler.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\re.h">
+    <ClInclude Include="..\..\src\JsonWriter.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\SharedResources.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
@@ -231,6 +234,12 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\re.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\JsonWriter.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\SharedResources.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
Introduces the concept of 'shared resources', which are logical/virtual entities that can be used by multiple nodes. This is intended to be used for e.g. compiler servers.

Each shared resource has a command it can run when it is created, and a command it can run when deleted.

The shared resource is created just-in-time by the first node that needs it, and then destroyed at the end of the build. If no nodes in a given build execution need the resource then it's never created or destroyed.

Also, a minor improvement to non-node progress reporting (e.g. running the frontend) - it now uses a codepath that will not display the broken "0/0" node count information.