### PR TITLE
add support for banning content digest for inputs

### DIFF
--- a/src/BuildQueue.cpp
+++ b/src/BuildQueue.cpp
@@ -558,6 +558,8 @@ namespace t2
 
     const ScannerData* scanner = node_data->m_Scanner;
 
+    bool force_use_timestamp = node_data->m_Flags | NodeData::kFlagBanContentDigestForInputs;
+
     // TODO: The input files are not guaranteed to be in a stably sorted order. If the order changes then the input
     // signature might change, giving us a false-positive for the node needing to be rebuilt. We should look into
     // enforcing a stable ordering, probably when we compile the DAG.
@@ -565,7 +567,15 @@ namespace t2
     {
       // Add path and timestamp of every direct input file.
       HashAddPath(&sighash, input.m_Filename);
-      ComputeFileSignature(&sighash, stat_cache, digest_cache, input.m_Filename, input.m_FilenameHash, config.m_ShaDigestExtensions, config.m_ShaDigestExtensionCount);
+      ComputeFileSignature(
+        &sighash,
+        stat_cache,
+        digest_cache,
+        input.m_Filename,
+        input.m_FilenameHash,
+        config.m_ShaDigestExtensions,
+        config.m_ShaDigestExtensionCount,
+        force_use_timestamp);
 
       if (scanner)
       {
@@ -588,7 +598,15 @@ namespace t2
             // Add path and timestamp of every indirect input file (#includes)
             const FileAndHash& path = scan_output.m_IncludedFiles[i];
             HashAddPath(&sighash, path.m_Filename);
-            ComputeFileSignature(&sighash, stat_cache, digest_cache, path.m_Filename, path.m_FilenameHash, config.m_ShaDigestExtensions, config.m_ShaDigestExtensionCount);
+            ComputeFileSignature(
+              &sighash,
+              stat_cache,
+              digest_cache,
+              path.m_Filename,
+              path.m_FilenameHash,
+              config.m_ShaDigestExtensions,
+              config.m_ShaDigestExtensionCount,
+              force_use_timestamp);
           }
         }
       }

--- a/src/DagData.hpp
+++ b/src/DagData.hpp
@@ -105,7 +105,8 @@ struct NodeData
     kFlagAllowUnexpectedOutput = 1 << 3,
     
     kFlagIsWriteTextFileAction = 1 << 4,
-    kFlagAllowUnwrittenOutputFiles = 1 << 5
+    kFlagAllowUnwrittenOutputFiles = 1 << 5,
+    kFlagBanContentDigestForInputs = 1 << 6
   };
 
   FrozenString                    m_Action;

--- a/src/DagGenerator.cpp
+++ b/src/DagGenerator.cpp
@@ -384,11 +384,13 @@ static bool WriteNodes(
 
     uint32_t flags = 0;
 
-    flags |= GetNodeFlag(node, "OverwriteOutputs", NodeData::kFlagOverwriteOutputs);
+    flags |= GetNodeFlag(node, "OverwriteOutputs", NodeData::kFlagOverwriteOutputs, true);
     flags |= GetNodeFlag(node, "PreciousOutputs",  NodeData::kFlagPreciousOutputs);
     flags |= GetNodeFlag(node, "Expensive",        NodeData::kFlagExpensive);
     flags |= GetNodeFlag(node, "AllowUnexpectedOutput", NodeData::kFlagAllowUnexpectedOutput, false);
     flags |= GetNodeFlag(node, "AllowUnwrittenOutputFiles", NodeData::kFlagAllowUnwrittenOutputFiles, false);
+    flags |= GetNodeFlag(node, "BanContentDigestForInputs", NodeData::kFlagBanContentDigestForInputs, false);
+
     if (writetextfile_payload != nullptr)
       flags |= NodeData::kFlagIsWriteTextFileAction;
     

--- a/src/FileSign.cpp
+++ b/src/FileSign.cpp
@@ -89,7 +89,7 @@ void ComputeFileSignature(
   int                 sha_extension_hash_count,
   bool                force_use_timestamp)
 {
-  if (force_use_timestamp || ShouldUseSHA1SignatureFor(filename, sha_extension_hashes, sha_extension_hash_count))
+  if (!force_use_timestamp && ShouldUseSHA1SignatureFor(filename, sha_extension_hashes, sha_extension_hash_count))
     ComputeFileSignatureSha1(out, stat_cache, digest_cache, filename, fn_hash);
   else
     ComputeFileSignatureTimestamp(out, stat_cache, filename, fn_hash);

--- a/src/FileSign.cpp
+++ b/src/FileSign.cpp
@@ -86,9 +86,10 @@ void ComputeFileSignature(
   const char*         filename,
   uint32_t            fn_hash,
   const uint32_t      sha_extension_hashes[],
-  int                 sha_extension_hash_count)
+  int                 sha_extension_hash_count,
+  bool                force_use_timestamp)
 {
-  if (ShouldUseSHA1SignatureFor(filename, sha_extension_hashes, sha_extension_hash_count))
+  if (force_use_timestamp || ShouldUseSHA1SignatureFor(filename, sha_extension_hashes, sha_extension_hash_count))
     ComputeFileSignatureSha1(out, stat_cache, digest_cache, filename, fn_hash);
   else
     ComputeFileSignatureTimestamp(out, stat_cache, filename, fn_hash);

--- a/src/FileSign.hpp
+++ b/src/FileSign.hpp
@@ -20,7 +20,8 @@ void ComputeFileSignature(
   const char*         filename,
   uint32_t            fn_hash,
   const uint32_t      sha_extension_hashes[],
-  int                 sha_extension_hash_count);
+  int                 sha_extension_hash_count,
+  bool                force_use_timestamp);
 
   HashDigest CalculateGlobSignatureFor(const char* path, MemAllocHeap* heap, MemAllocLinear* scratch);
 


### PR DESCRIPTION
because clang on osx complains if the .h timestamps change but we don't rebuild the pch because the content didn't change