### PR TITLE
Change "error" output color to bright red

### DIFF
--- a/src/NodeResultPrinting.cpp
+++ b/src/NodeResultPrinting.cpp
@@ -149,7 +149,7 @@ static void EmitColor(const char* colorsequence)
   }
 }
 
-#define RED   "\x1B[31m"
+#define RED   "\x1B[91m"
 #define GRN   "\x1B[32m"
 #define YEL   "\x1B[33m"
 #define BLU   "\x1B[34m"


### PR DESCRIPTION
Makes it much more legible on default windows powershell blue background.

Windows Powershell, before and after:
![powershell-before](https://user-images.githubusercontent.com/348087/48246638-d8977800-e3f8-11e8-8ea5-34828c07693e.png)
![powershell-after](https://user-images.githubusercontent.com/348087/48246639-daf9d200-e3f8-11e8-837e-86fe977d21bd.png)

Mac Terminal, before and after:
<img width="443" alt="macterminal-before" src="https://user-images.githubusercontent.com/348087/48246644-e0efb300-e3f8-11e8-91b0-6556944fb1a5.png">
<img width="435" alt="macterminal-after" src="https://user-images.githubusercontent.com/348087/48246646-e4833a00-e3f8-11e8-9df4-7369dec66898.png">
