### PR TITLE
Fix crash when # of jobs/threads is larger than the max we support

### DIFF
--- a/src/BuildQueue.cpp
+++ b/src/BuildQueue.cpp
@@ -1334,7 +1334,7 @@ namespace t2
 
     CondBroadcast(&queue->m_WorkAvailable);
 
-    for (int i = 0, thread_count = config->m_ThreadCount; i < thread_count; ++i)
+    for (int i = 0, thread_count = queue->m_Config.m_ThreadCount; i < thread_count; ++i)
     {
       if (i > 0)
       {


### PR DESCRIPTION
The code was reading the input struct that is const and has not been clamped to max # of jobs.