### PR TITLE
Stable implicit deps

### DIFF
--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -1100,7 +1100,8 @@ bool DriverSaveBuildState(Driver* self)
           for (int i = 0, count = scan_output.m_IncludedFileCount; i < count; ++i)
           {
             const FileAndHash& path = scan_output.m_IncludedFiles[i];
-            HashSetInsert(&implicitDependencies, path.m_FilenameHash, path.m_Filename);
+            if (!HashSetLookup(&implicitDependencies, path.m_FilenameHash, path.m_Filename))
+              HashSetInsert(&implicitDependencies, path.m_FilenameHash, path.m_Filename);
           }
         }
       }

--- a/vs2017/libtundra/libtundra.vcxproj
+++ b/vs2017/libtundra/libtundra.vcxproj
@@ -164,6 +164,9 @@
     <ClCompile Include="..\..\src\OutputValidation.cpp" />
     <ClCompile Include="..\..\src\re.c" />
   </ItemGroup>
+  <ItemGroup>
+    <Natvis Include="Tundra.natvis" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/vs2017/libtundra/libtundra.vcxproj.filters
+++ b/vs2017/libtundra/libtundra.vcxproj.filters
@@ -243,4 +243,7 @@
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
+  <ItemGroup>
+    <Natvis Include="Tundra.natvis" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Change input signature calculation for implicit dependencies to ensure a stable ordering with no duplicates.

Also add the natvis file to the vcxproj.