### PR TITLE
Add "report includes" command

### DIFF
--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -339,7 +339,10 @@ bool DriverInitData(Driver* self)
   if (!DriverPrepareDag(self, s_DagFileName))
     return false;
 
-  SetStructuredLogFileName(self->m_DagData->m_StructuredLogFileName);
+  // do not produce/overwrite structured log output file,
+  // if we're only reporting something and not doing an actual build
+  if (self->m_Options.m_IncludesOutput == nullptr && !self->m_Options.m_ShowHelp && !self->m_Options.m_ShowTargets)
+    SetStructuredLogFileName(self->m_DagData->m_StructuredLogFileName);
 
   DigestCacheInit(&self->m_DigestCache, MB(128), self->m_DagData->m_DigestCacheFileName);
 

--- a/src/Driver.hpp
+++ b/src/Driver.hpp
@@ -43,6 +43,7 @@ struct DriverOptions
   const char *m_WorkingDir;
   const char *m_DAGFileName;
   const char *m_ProfileOutput;
+  const char *m_IncludesOutput;
 };
 
 void DriverOptionsInit(DriverOptions* self);
@@ -99,6 +100,7 @@ void DriverDestroy(Driver* self);
 void DriverShowHelp(Driver* self);
 
 void DriverShowTargets(Driver* self);
+bool DriverReportIncludes(Driver* self);
 
 void DriverReportStartup(Driver* self, const char** targets, int target_count);
 

--- a/src/JsonWriter.cpp
+++ b/src/JsonWriter.cpp
@@ -52,6 +52,12 @@ static void JsonWriteChar(JsonWriter* writer, char ch)
   JsonWrite(writer, &ch, 1);
 }
 
+void JsonWriteNewline(JsonWriter* writer)
+{
+  JsonWrite(writer, "\n", 1);
+}
+
+
 void JsonWriteStartObject(JsonWriter* writer)
 {
     if (writer->m_PrependComma)

--- a/src/JsonWriter.hpp
+++ b/src/JsonWriter.hpp
@@ -33,6 +33,8 @@ void JsonWriteKeyName(JsonWriter* writer, const char* keyName);
 void JsonWriteValueString(JsonWriter* writer, const char* value, size_t maxLen = (size_t)-1);
 void JsonWriteValueInteger(JsonWriter* writer, int64_t value);
 
+void JsonWriteNewline(JsonWriter* writer);
+
 void JsonWriteToFile(JsonWriter* writer, FILE* fp);
 
 }

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -76,6 +76,8 @@ static const struct OptionTemplate
     "Set working directory before building" },
   { 'R', "dagfile", OptionType::kString, offsetof(t2::DriverOptions, m_DAGFileName),
     "filename of where tundra should store the mmapped dag file"},
+  { 'I', "report-includes", OptionType::kString, offsetof(t2::DriverOptions, m_IncludesOutput),
+    "Output included files into a json file and exit" },
   { 'h', "help", OptionType::kBool, offsetof(t2::DriverOptions, m_ShowHelp),
     "Show help" },
   { 'k', "continue", OptionType::kBool, offsetof(t2::DriverOptions, m_ContinueOnError),
@@ -446,6 +448,13 @@ int main(int argc, char* argv[])
     DriverShowTargets(&driver);
     Log(kDebug, "Only showing targets - quitting");
     build_result = BuildResult::kOk;
+    goto leave;
+  }
+
+  if (driver.m_Options.m_IncludesOutput != nullptr)
+  {
+    build_result = DriverReportIncludes(&driver) ? BuildResult::kOk : BuildResult::kSetupError;
+    Log(kDebug, "Only reporting includes - quitting");
     goto leave;
   }
 


### PR DESCRIPTION
Adds a command that given a DAG, looks at the nodes in it and the includes scan cache from the previous build, and reports which files include which other files into JSON format.

The JSON looks something like this:
```
{
  "dagFile":"C:/code/BeeDistribution/artifacts/tundra.dag",
  "files":[
    {
      "file":"sdk/ucrt/corecrt_stdio_config.h",
      "includes":[
        "sdk/ucrt/corecrt.h"
      ]
    },
    {
      "file":"sdk/ucrt/corecrt_malloc.h",
      "includes":[
        "sdk/ucrt/corecrt.h"
      ]
    },
    {
      "file":"sdk/shared/winpackagefamily.h",
      "includes":[

      ]
    },
    {
      "file":"compiler/include/CodeAnalysis/sourceannotations.h",
      "includes":[

      ]
    },
    {
      "file":"include.h",
      "includes":[
        "include.h",
        "sdk/ucrt/stdlib.h"
      ]
    },
    {
      "file":"sdk/ucrt/corecrt_search.h",
      "includes":[
        "sdk/ucrt/corecrt.h",
        "sdk/ucrt/stddef.h"
      ]
    },
    {
      "file":"sdk/ucrt/corecrt_wstdlib.h",
      "includes":[
        "sdk/ucrt/corecrt.h"
      ]
    },
    {
      "file":"sdk/ucrt/corecrt_wstdio.h",
      "includes":[
        "sdk/ucrt/corecrt.h",
        "sdk/ucrt/corecrt_stdio_config.h"
      ]
    },
    {
      "file":"compiler/include/concurrencysal.h",
      "includes":[

      ]
    },
    {
      "file":"compiler/include/limits.h",
      "includes":[
        "compiler/include/vcruntime.h"
      ]
    },
    {
      "file":"test.cpp",
      "direct":1,
      "includes":[
        "sdk/ucrt/stdio.h",
        "include.h"
      ]
    },
    {
      "file":"sdk/shared/winapifamily.h",
      "includes":[
        "sdk/shared/winpackagefamily.h"
      ]
    },
    {
      "file":"compiler/include/sal.h",
      "includes":[
        "compiler/include/CodeAnalysis/sourceannotations.h",
        "compiler/include/concurrencysal.h"
      ]
    },
    {
      "file":"sdk/ucrt/corecrt.h",
      "includes":[
        "compiler/include/vcruntime.h",
        "sdk/shared/winapifamily.h"
      ]
    },
    {
      "file":"sdk/ucrt/stddef.h",
      "includes":[
        "sdk/ucrt/corecrt.h"
      ]
    },
    {
      "file":"compiler/include/vadefs.h",
      "includes":[

      ]
    },
    {
      "file":"sdk/ucrt/stdlib.h",
      "includes":[
        "sdk/ucrt/corecrt.h",
        "sdk/ucrt/corecrt_malloc.h",
        "sdk/ucrt/corecrt_search.h",
        "sdk/ucrt/corecrt_wstdlib.h",
        "compiler/include/limits.h"
      ]
    },
    {
      "file":"sdk/ucrt/stdio.h",
      "includes":[
        "sdk/ucrt/corecrt.h",
        "sdk/ucrt/corecrt_wstdio.h"
      ]
    },
    {
      "file":"compiler/include/vcruntime.h",
      "includes":[
        "compiler/include/sal.h",
        "compiler/include/vadefs.h"
      ]
    }
  ]
}
```