### PR TITLE
Improve error handling and detection

### DIFF
--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -59,6 +59,20 @@ static void NORETURN FlushAndAbort()
   abort();
 }
 
+static void PrintErrno()
+{
+#if TUNDRA_WIN32
+  wchar_t buf[256];
+  DWORD lastError = GetLastError();
+  FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+    NULL, lastError, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+    buf, sizeof(buf), NULL);
+  fprintf(stderr, "errno: %d (%s) GetLastError: %d (0x%08X): %ls\n", errno, strerror(errno), (int)lastError, (unsigned int)lastError, buf);
+#else
+  fprintf(stderr, "errno: %d (%s)\n", errno, strerror(errno));
+#endif
+}
+
 void InitCommon(void)
 {
 #if defined(TUNDRA_WIN32)
@@ -73,6 +87,7 @@ void InitCommon(void)
 
 void NORETURN Croak(const char* fmt, ...)
 {
+  fputs("tundra: error: ", stderr);
   va_list args;
   va_start(args, fmt);
   vfprintf(stderr, fmt, args);
@@ -86,21 +101,13 @@ void NORETURN Croak(const char* fmt, ...)
 
 void NORETURN CroakErrno(const char* fmt, ...)
 {
+  fputs("tundra: error: ", stderr);
   va_list args;
   va_start(args, fmt);
   vfprintf(stderr, fmt, args);
   va_end(args);
   fprintf(stderr, "\n");
-#if TUNDRA_WIN32
-  wchar_t buf[256];
-  DWORD lastError = GetLastError();
-  FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-               NULL, lastError, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), 
-               buf, sizeof(buf), NULL);
-  fprintf(stderr, "errno: %d (%s) GetLastError %d (%ls)\n", errno, strerror(errno), lastError, buf);
-#else
-  fprintf(stderr, "errno: %d (%s)\n", errno, strerror(errno));
-#endif
+  PrintErrno();
   if (DebuggerAttached())
     FlushAndAbort();
   else
@@ -109,11 +116,24 @@ void NORETURN CroakErrno(const char* fmt, ...)
 
 void NORETURN CroakAbort(const char* fmt, ...)
 {
+  fputs("tundra: error: ", stderr);
   va_list args;
   va_start(args, fmt);
   vfprintf(stderr, fmt, args);
   va_end(args);
   fprintf(stderr, "\n");
+  FlushAndAbort();
+}
+
+void NORETURN CroakErrnoAbort(const char* fmt, ...)
+{
+  fputs("tundra: error: ", stderr);
+  va_list args;
+  va_start(args, fmt);
+  vfprintf(stderr, fmt, args);
+  va_end(args);
+  fprintf(stderr, "\n");
+  PrintErrno();
   FlushAndAbort();
 }
 
@@ -255,10 +275,10 @@ void GetCwd(char* buffer, size_t buffer_size)
 #if defined(TUNDRA_WIN32)
   DWORD res = GetCurrentDirectoryA((DWORD)buffer_size, buffer);
   if (0 == res || ((DWORD)buffer_size) <= res)
-    Croak("couldn't get working directory");
+    CroakErrno("couldn't get working directory");
 #elif defined(TUNDRA_UNIX)
   if (NULL == getcwd(buffer, buffer_size))
-    Croak("couldn't get working directory");
+    CroakErrno("couldn't get working directory");
 #else
 #error Unsupported platform
 #endif
@@ -283,14 +303,14 @@ const char* GetExePath()
   {
 #if defined(TUNDRA_WIN32)
     if (!GetModuleFileNameA(NULL, s_ExePath, (DWORD)sizeof s_ExePath))
-      Croak("couldn't get module filename");
+      CroakErrno("couldn't get module filename");
 #elif defined(TUNDRA_APPLE)
     uint32_t size = sizeof s_ExePath;
     if (0 != _NSGetExecutablePath(s_ExePath, &size))
       Croak("_NSGetExecutablePath failed");
 #elif defined(TUNDRA_LINUX)
     if (-1 == readlink("/proc/self/exe", s_ExePath, (sizeof s_ExePath) - 1))
-      Croak("couldn't read /proc/self/exe to get exe path: %s", strerror(errno));
+      CroakErrno("couldn't read /proc/self/exe to get exe path");
 #elif defined(TUNDRA_FREEBSD)
     size_t cb = sizeof s_ExePath;
     int mib[4];
@@ -299,7 +319,7 @@ const char* GetExePath()
     mib[2] = KERN_PROC_PATHNAME;
     mib[3] = -1;
     if (0 !=sysctl(mib, 4, s_ExePath, &cb, NULL, 0))
-      Croak("KERN_PROC_PATHNAME syscall failed");
+      CroakErrno("KERN_PROC_PATHNAME syscall failed");
 #else
 #error "unsupported platform"
 #endif

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -97,7 +97,7 @@ void NORETURN CroakErrno(const char* fmt, ...)
   FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
                NULL, lastError, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), 
                buf, sizeof(buf), NULL);
-  fprintf(stderr, "errno: %d (%s) GetLastError %d (%s)\n", errno, strerror(errno), lastError, buf);
+  fprintf(stderr, "errno: %d (%s) GetLastError %d (%ls)\n", errno, strerror(errno), lastError, buf);
 #else
   fprintf(stderr, "errno: %d (%s)\n", errno, strerror(errno));
 #endif

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -51,6 +51,14 @@ static bool DebuggerAttached()
 #endif
 }
 
+static void NORETURN FlushAndAbort()
+{
+  // The C standard does not require 'abort' to flush stream buffers.
+  // On Windows at least, an explicit 'fflush' is required for stderr messages to actually be shown.
+  fflush(NULL);
+  abort();
+}
+
 void InitCommon(void)
 {
 #if defined(TUNDRA_WIN32)
@@ -71,7 +79,7 @@ void NORETURN Croak(const char* fmt, ...)
   va_end(args);
   fprintf(stderr, "\n");
   if (DebuggerAttached())
-    abort();
+    FlushAndAbort();
   else
     exit(1);
 }
@@ -94,7 +102,7 @@ void NORETURN CroakErrno(const char* fmt, ...)
   fprintf(stderr, "errno: %d (%s)\n", errno, strerror(errno));
 #endif
   if (DebuggerAttached())
-    abort();
+    FlushAndAbort();
   else
     exit(1);
 }
@@ -106,7 +114,7 @@ void NORETURN CroakAbort(const char* fmt, ...)
   vfprintf(stderr, fmt, args);
   va_end(args);
   fprintf(stderr, "\n");
-  abort();
+  FlushAndAbort();
 }
 
 uint32_t Djb2Hash(const char *str_)

--- a/src/Common.hpp
+++ b/src/Common.hpp
@@ -52,6 +52,9 @@ void NORETURN CroakErrno(const char* fmt, ...);
 // Abort the program with an error message on stderr
 void NORETURN CroakAbort(const char* fmt, ...);
 
+// Abort the program with an error message on stderr, also printing the errno/GetLastError() status
+void NORETURN CroakErrnoAbort(const char* fmt, ...);
+
 //-----------------------------------------------------------------------------
 // Logging
 //-----------------------------------------------------------------------------

--- a/src/ExecWin32.cpp
+++ b/src/ExecWin32.cpp
@@ -70,10 +70,7 @@ static HANDLE GetOrCreateTempFileFor(int job_id)
     result = CreateFileA(temp_dir, access, sharemode, NULL, disp, flags, NULL);
 
     if (INVALID_HANDLE_VALUE == result)
-    {
-      fprintf(stderr, "failed to create temporary file %s\n", temp_dir);
-      return INVALID_HANDLE_VALUE;
-    }
+      CroakErrno("failed to create temporary file: %s", temp_dir);
 
     SetHandleInformation(result, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT);
 

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -341,7 +341,7 @@ int main(int argc, char* argv[])
   if (options.m_WorkingDir)
   {
     if (!SetCwd(options.m_WorkingDir))
-      Croak("couldn't change directory to %s", options.m_WorkingDir);
+      CroakErrno("couldn't change directory to %s", options.m_WorkingDir);
   }
 
   if (options.m_ShowHelp)

--- a/src/MemoryMappedFile.cpp
+++ b/src/MemoryMappedFile.cpp
@@ -73,7 +73,7 @@ void MmapFileUnmap(MemoryMappedFile* self)
     TimingScope timing_scope(&g_Stats.m_MunmapCalls, &g_Stats.m_MunmapTimeCycles);
 
     if (0 != munmap(self->m_Address, self->m_Size))
-      Croak("munmap(%p, %d) failed: %d", self->m_Address, (int) self->m_Size, errno);
+      CroakErrno("munmap(%p, %d) failed", self->m_Address, (int) self->m_Size);
 
     close((int) self->m_SysData[0]);
   }


### PR DESCRIPTION
The first four commits are essentially bug fixes, and probably uncontroversial.

The last commit, 843125c, detects an error that previously could have caused silent malfunction [or crashes](https://unity.slack.com/archives/C76011S67/p1550522613233300), but the detection may have a minuscule performance impact, as it adds 2 new file system operations per build action (on Windows only): the temp stdout/stderr files are now deleted and recreated for each build action, instead of only once per worker thread. Compared to the overhead of launching a build command (even something completely trivial, like copy), the overhead is expected to be below the noise floor.

No new tests are added, though the new error handling has been manually tested with misbehaving build code.

Example output showing the new Tundra code detecting and reporting (an earlier, unfinished and buggy iteration of) the async Stevedore telemetry code:

    tundra: error: failed to create temporary file: C:\Users\sorenl\AppData\Local\Temp\tundra.1860.1
    The just completed command was: cmd.exe /c "C:\data\u\unity\artifacts\Bee.CSharpSupport\Bee.Stevedore.Unity.Tests\Debug\Bee.Stevedore.Program.exe steve internal-unpack public 7za-win-x64/16.04-1.1.4_0d1e6ad367de3bb0c1a396856903c63e080a1e8fee52897cb5f5dee063832831.zip "artifacts/Stevedore/7za-win-x64""
    Most likely, the build action spawned a lingering subprocess that is keeping stdout/stderr open (this is not allowed).
    errno: 2 (No such file or directory) GetLastError: 32 (0x00000020): The process cannot access the file because it is being used by another process.
