### PR TITLE
Windows: show (better) diagnostics when a lingering process is found to keep Tundra temp file open

### DIFF
--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -59,7 +59,7 @@ static void NORETURN FlushAndAbort()
   abort();
 }
 
-static void PrintErrno()
+void PrintErrno()
 {
 #if TUNDRA_WIN32
   wchar_t buf[256];

--- a/src/Common.hpp
+++ b/src/Common.hpp
@@ -43,6 +43,9 @@ void InitCommon(void);
 // Error handling
 //-----------------------------------------------------------------------------
 
+// Print the most recent OS error (errno, and GetLastError on Windows)
+void PrintErrno();
+
 // Terminate the program with an error message on stderr
 void NORETURN Croak(const char* fmt, ...);
 

--- a/vs2017/libtundra/libtundra.vcxproj
+++ b/vs2017/libtundra/libtundra.vcxproj
@@ -63,6 +63,9 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
+    <Lib>
+      <AdditionalDependencies>Rstrtmgr.lib</AdditionalDependencies>
+    </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -81,6 +84,9 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
+    <Lib>
+      <AdditionalDependencies>Rstrtmgr.lib</AdditionalDependencies>
+    </Lib>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\Atomic.hpp" />


### PR DESCRIPTION
Follow-up to https://github.com/Unity-Technologies/tundra/pull/39, which has revealed more apparent instances of build commands leaving lingering child processes behind.

If approved, I'll take the updated Tundra directly to trunk, to hopefully identify the culprit.

When Tundra can't (re)create the tempfile used on Windows for buffering build action output (presumably because a lingering child process is keeping it open), use the Windows "Restart Manager" API to list the actual processes keeping the file open. (API available as of Windows Vista.)

Example output:

    tundra: found 1 processes keeping the file "C:\Users\sorenl\AppData\Local\Temp\tundra.12704.2" open (showing 1).
    - " " (PID 13840)
        C:\data\u\unity\artifacts\Bee.CSharpSupport\Bee.Stevedore.Unity.Tests\Debug\Bee.Stevedore.Program.exe
    tundra: error: failed to create temporary file: C:\Users\sorenl\AppData\Local\Temp\tundra.12704.2
    The just completed command was: cmd.exe /c "C:\data\u\unity\artifacts\Bee.CSharpSupport\Bee.Stevedore.Unity.Tests\Debug\Bee.Stevedore.Program.exe steve internal-unpack public 7za-win-x64/16.04-1.1.4_0d1e6ad367de3bb0c1a396856903c63e080a1e8fee52897cb5f5dee063832831.zip "artifacts/Stevedore/7za-win-x64""
    Most likely, the build action spawned a lingering subprocess that is keeping stdout/stderr open (this is not allowed).
    errno: 2 (No such file or directory) GetLastError: 32 (0x00000020): The process cannot access the file because it is being used by another process.

The listing shows the Windows "application name" of the offending process, because that's the only information guaranteed to be available. (When possible, the .exe path is also shown.)

For some reason, Bee is built with the application name set to a single space, leading to the output `- " " (PID 13840)` in the example above. Most programs will instead either have a "friendly name", or just show the .exe filename, for example:

    - "MSBuild.exe" (PID 9940)
    - "Microsoft Visual Studio 2017" (PID 11140)