### PR TITLE
Fix "tundra constantly rebuilds" bug due to uninitialized/garbage data

### DIFF
--- a/src/BuildQueue.cpp
+++ b/src/BuildQueue.cpp
@@ -597,6 +597,9 @@ namespace t2
 
     bool force_use_timestamp = node_data->m_Flags & NodeData::kFlagBanContentDigestForInputs;
 
+    // Roll back scratch allocator after all file scans
+    MemAllocLinearScope alloc_scope(&thread_state->m_ScratchAlloc);
+
     for (const FrozenFileAndHash& input : node_data->m_InputFiles)
     {
       // Add path and timestamp of every direct input file.
@@ -613,9 +616,6 @@ namespace t2
 
       if (scanner)
       {
-        // Roll back scratch allocator between scans
-        MemAllocLinearScope alloc_scope(&thread_state->m_ScratchAlloc);
-
         ScanInput scan_input;
         scan_input.m_ScannerConfig = scanner;
         scan_input.m_ScratchAlloc  = &thread_state->m_ScratchAlloc;


### PR DESCRIPTION
#36 changed so that C++ include scans are done into a hashset, which then is processed in hash order (to get stable ordering).

However between scanning each input file, the scratch allocator was being reset, so for actions that had multiple input files (e.g. using precompiled header), the scans of the later ones trampled over some of the filenames in previous scan. The hashset processing was getting garbage filenames, and thus not adding their entries into digest cache.

Now don't reset the scratch allocator between each input file scan; just around the loop that processes all of them. On Windows Standalone player build, max usage of temp scratch allocator increases from 210kb/thread to 225kb/thread on average, which sounds acceptable (temp allocator has 32MB capacity)