### PR TITLE
Implement --dry-run flag

### DIFF
--- a/src/BuildQueue.hpp
+++ b/src/BuildQueue.hpp
@@ -33,7 +33,9 @@ namespace t2
       // Print annotations to the TTY as actions are executed
       kFlagEchoAnnotations    = 1 << 1,
       // Continue building even if there are errors.
-      kFlagContinueOnError    = 1 << 2
+      kFlagContinueOnError    = 1 << 2,
+      // Figure out which nodes need building, but do not actually execute any actions
+      kFlagDryRun             = 1 << 3
     };
 
     uint32_t        m_Flags;

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -979,6 +979,10 @@ BuildResult::Enum DriverBuild(Driver* self)
   {
     queue_config.m_Flags |= BuildQueueConfig::kFlagContinueOnError;
   }
+  if (self->m_Options.m_DryRun)
+  {
+    queue_config.m_Flags |= BuildQueueConfig::kFlagDryRun;
+  }
 
   if (self->m_Options.m_DebugSigning)
   {

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -482,7 +482,7 @@ int main(int argc, char* argv[])
 
   build_result = DriverBuild(&driver);
 
-  if (!DriverSaveBuildState(&driver))
+  if (!driver.m_Options.m_DryRun && !DriverSaveBuildState(&driver))
     Log(kError, "Couldn't save build state");
 
   if (!DriverSaveScanCache(&driver))

--- a/src/NodeResultPrinting.cpp
+++ b/src/NodeResultPrinting.cpp
@@ -100,7 +100,6 @@ void InitNodeResultPrinting()
     if (isatty(fileno(stdout)))
     {
         EmitColors = true;
-        return;
     }
 #endif
 


### PR DESCRIPTION
It looks like the --dry-run flag has not actually been implemented for a few years now, despite being listed in the options. This PR makes it actually function, by having it skip the actual 'run actions' parts during the build, while still keeping stats (so we still get a count of how many items it wants to update, etc).

Also, I noticed that the DOWNSTREAM_CONSUMER_SUPPORTS_COLORS env var was just being ignored on macOS/Linux, so I fixed that.