### PR TITLE
Filter the files used to calculate a glob signature

### DIFF
--- a/src/DagData.hpp
+++ b/src/DagData.hpp
@@ -74,9 +74,10 @@ static_assert(sizeof(DagFileSignature) == 16, "struct layout");
 struct DagGlobSignature
 {
   FrozenString      m_Path;
+  FrozenString      m_Filter;
   HashDigest        m_Digest;
 };
-static_assert(sizeof(HashDigest) + sizeof(FrozenString) == sizeof(DagGlobSignature), "struct layout");
+static_assert(sizeof(HashDigest) + sizeof(FrozenString) + sizeof(FrozenString) == sizeof(DagGlobSignature), "struct layout");
 
 struct EnvVarData
 {

--- a/src/DagGenerator.cpp
+++ b/src/DagGenerator.cpp
@@ -993,10 +993,13 @@ static bool CompileDag(const JsonObjectValue* root, BinaryWriter* writer, MemAll
           fprintf(stderr, "bad GlobSignatures data\n");
           return false;
         }
+          
+        const char* filter = FindStringValue(sig, "Filter");
 
-        HashDigest digest = CalculateGlobSignatureFor(path, heap, scratch);
+        HashDigest digest = CalculateGlobSignatureFor(path, filter, heap, scratch);
 
         WriteStringPtr(aux_seg, str_seg, path);
+        WriteStringPtr(aux_seg, str_seg, filter);
         BinarySegmentWrite(aux_seg, (char*) &digest, sizeof digest);
       }
     }

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -470,7 +470,7 @@ static bool DriverCheckDagSignatures(Driver* self, char* out_of_date_reason, int
   // The digests computed there are stored in the signature block by frontend code.
   for (const DagGlobSignature& sig : dag_data->m_GlobSignatures)
   {
-    HashDigest digest = CalculateGlobSignatureFor(sig.m_Path, &self->m_Heap, &self->m_Allocator);
+    HashDigest digest = CalculateGlobSignatureFor(sig.m_Path, sig.m_Filter, &self->m_Heap, &self->m_Allocator);
 
     // Compare digest with the one stored in the signature block
     if (0 != memcmp(&digest, &sig.m_Digest, sizeof digest))

--- a/src/FileInfo.cpp
+++ b/src/FileInfo.cpp
@@ -25,6 +25,7 @@ extern "C" {
 #include <fnmatch.h>
 #elif defined(TUNDRA_WIN32)
 #include <windows.h>
+#include <shlwapi.h>
 #endif
 
 namespace t2

--- a/src/FileInfo.hpp
+++ b/src/FileInfo.hpp
@@ -33,6 +33,7 @@ bool ShouldFilter(const char* name, size_t len);
 
 void ListDirectory(
     const char* dir,
+    const char* filter,
     void* user_data,
     void (*callback)(void* user_data, const FileInfo& info, const char* path));
 

--- a/src/FileSign.cpp
+++ b/src/FileSign.cpp
@@ -95,7 +95,7 @@ void ComputeFileSignature(
     ComputeFileSignatureTimestamp(out, stat_cache, filename, fn_hash);
 }
 
-t2::HashDigest CalculateGlobSignatureFor(const char* path, t2::MemAllocHeap* heap, t2::MemAllocLinear* scratch)
+t2::HashDigest CalculateGlobSignatureFor(const char* path, const char* filter, t2::MemAllocHeap* heap, t2::MemAllocLinear* scratch)
 {
     // Helper for directory iteration + memory allocation of strings.  We need to
     // buffer the filenames as we need them in sorted order to ensure the results
@@ -143,7 +143,7 @@ t2::HashDigest CalculateGlobSignatureFor(const char* path, t2::MemAllocHeap* hea
     ctx.Init(heap, scratch);
 
     // Get directory data
-    ListDirectory(path, &ctx, IterContext::Callback);
+    ListDirectory(path, filter, &ctx, IterContext::Callback);
 
     // Sort data
     qsort(ctx.m_Dirs.m_Storage, ctx.m_Dirs.m_Size, sizeof(const char*), IterContext::SortStringPtrs);

--- a/src/FileSign.hpp
+++ b/src/FileSign.hpp
@@ -23,7 +23,7 @@ void ComputeFileSignature(
   int                 sha_extension_hash_count,
   bool                force_use_timestamp);
 
-  HashDigest CalculateGlobSignatureFor(const char* path, MemAllocHeap* heap, MemAllocLinear* scratch);
+  HashDigest CalculateGlobSignatureFor(const char* path, const char* filter, MemAllocHeap* heap, MemAllocLinear* scratch);
 
   bool ShouldUseSHA1SignatureFor(const char* filename, const uint32_t sha_extension_hashes[], int sha_extension_hash_count);
 

--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -241,7 +241,7 @@ static int LuaListDirectory(lua_State* L)
   // Push file result table on stack
   lua_newtable(L);
 
-  ListDirectory(dir, L, OnFileIter);
+  ListDirectory(dir, nullptr, L, OnFileIter);
 
   // Sort both tables
   lua_getglobal(L, "table");

--- a/vs2017/libtundra/libtundra.vcxproj
+++ b/vs2017/libtundra/libtundra.vcxproj
@@ -64,7 +64,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <Lib>
-      <AdditionalDependencies>Rstrtmgr.lib</AdditionalDependencies>
+      <AdditionalDependencies>Rstrtmgr.lib;Shlwapi.lib</AdditionalDependencies>
     </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -85,7 +85,7 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
     <Lib>
-      <AdditionalDependencies>Rstrtmgr.lib</AdditionalDependencies>
+      <AdditionalDependencies>Rstrtmgr.lib;Shlwapi.lib</AdditionalDependencies>
     </Lib>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
It's common that the files that determine whether the frontend must be rerun are not actually 'all files,' but instead 'all files that match a particular pattern,' e.g. "*.bee.cs". This change allows the frontend to optionally provide a filter expression for each GlobSignature which will be used to filter the files that should be accounted for.