### PR TITLE
Support for recursive GlobSignatures

### DIFF
--- a/src/DagData.hpp
+++ b/src/DagData.hpp
@@ -76,8 +76,9 @@ struct DagGlobSignature
   FrozenString      m_Path;
   FrozenString      m_Filter;
   HashDigest        m_Digest;
+  uint32_t          m_Recurse;
 };
-static_assert(sizeof(HashDigest) + sizeof(FrozenString) + sizeof(FrozenString) == sizeof(DagGlobSignature), "struct layout");
+static_assert(sizeof(HashDigest) + sizeof(FrozenString) + sizeof(FrozenString) + sizeof(uint32_t) == sizeof(DagGlobSignature), "struct layout");
 
 struct EnvVarData
 {

--- a/src/DagGenerator.cpp
+++ b/src/DagGenerator.cpp
@@ -995,12 +995,14 @@ static bool CompileDag(const JsonObjectValue* root, BinaryWriter* writer, MemAll
         }
           
         const char* filter = FindStringValue(sig, "Filter");
+        bool recurse = FindIntValue(sig, "Recurse", 0) == 1;
 
-        HashDigest digest = CalculateGlobSignatureFor(path, filter, heap, scratch);
+        HashDigest digest = CalculateGlobSignatureFor(path, filter, recurse, heap, scratch);
 
         WriteStringPtr(aux_seg, str_seg, path);
         WriteStringPtr(aux_seg, str_seg, filter);
         BinarySegmentWrite(aux_seg, (char*) &digest, sizeof digest);
+        BinarySegmentWriteInt32(aux_seg, recurse ? 1 : 0);
       }
     }
   }

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -470,7 +470,7 @@ static bool DriverCheckDagSignatures(Driver* self, char* out_of_date_reason, int
   // The digests computed there are stored in the signature block by frontend code.
   for (const DagGlobSignature& sig : dag_data->m_GlobSignatures)
   {
-    HashDigest digest = CalculateGlobSignatureFor(sig.m_Path, sig.m_Filter, &self->m_Heap, &self->m_Allocator);
+    HashDigest digest = CalculateGlobSignatureFor(sig.m_Path, sig.m_Filter, sig.m_Recurse, &self->m_Heap, &self->m_Allocator);
 
     // Compare digest with the one stored in the signature block
     if (0 != memcmp(&digest, &sig.m_Digest, sizeof digest))

--- a/src/FileInfo.cpp
+++ b/src/FileInfo.cpp
@@ -168,15 +168,15 @@ void ListDirectory(
 	WIN32_FIND_DATAA find_data;
 	char             scan_path[MAX_PATH];
 
-    const size_t pathLength = strlen(path);
-    if (pathLength >= sizeof(scan_path) + 3)
+    const size_t path_length = strlen(path);
+    if (path_length >= sizeof(scan_path) + 3)
     {
         Log(kWarning, "Path too long: %s", path);
         return;
     }
     
-    memcpy(scan_path, path, pathLength);
-    strcpy(scan_path + pathLength, "/*");
+    memcpy(scan_path, path, path_length);
+    strcpy(scan_path + path_length, "/*");
 
 	for (int i = 0; i < MAX_PATH; ++i)
 	{
@@ -203,7 +203,7 @@ void ListDirectory(
     if (!matchesFilter && !recurse)
       continue;
         
-    if (pathLength + strlen(find_data.cFileName) + 2 > MAX_PATH)
+    if (path_length + strlen(find_data.cFileName) + 2 > MAX_PATH)
     {
         Log(kWarning, "Path too long: %s/%s", path, find_data.cFileName);
         continue;

--- a/src/FileInfo.hpp
+++ b/src/FileInfo.hpp
@@ -34,6 +34,7 @@ bool ShouldFilter(const char* name, size_t len);
 void ListDirectory(
     const char* dir,
     const char* filter,
+    bool recurse,
     void* user_data,
     void (*callback)(void* user_data, const FileInfo& info, const char* path));
 

--- a/src/FileSign.cpp
+++ b/src/FileSign.cpp
@@ -134,40 +134,57 @@ t2::HashDigest CalculateGlobSignatureFor(const char* path, const char* filter, b
         return strcmp(*(const char**)l, *(const char**)r);
       }
     };
-
-    // Set up to rewind allocator for each loop iteration
-    MemAllocLinearScope mem_scope(scratch);
-
-    // Set up context
-    IterContext ctx;
-    ctx.Init(heap, scratch);
-
-    // Get directory data
-    ListDirectory(path, filter, recurse, &ctx, IterContext::Callback);
-
-    // Sort data
-    qsort(ctx.m_Dirs.m_Storage, ctx.m_Dirs.m_Size, sizeof(const char*), IterContext::SortStringPtrs);
-    qsort(ctx.m_Files.m_Storage, ctx.m_Files.m_Size, sizeof(const char*), IterContext::SortStringPtrs);
-
-    // Compute digest
+    
     HashState h;
     HashInit(&h);
-    for (const char* p : ctx.m_Dirs)
+    
+    FileInfo pathInfo = GetFileInfo(path);
+    HashAddInteger(&h, pathInfo.Exists() ? 1 : 0);
+    HashAddInteger(&h, pathInfo.IsDirectory() ? 1 : 0);
+    HashAddSeparator(&h);
+    
+    if (pathInfo.Exists() && pathInfo.IsDirectory())
     {
-      HashAddPath(&h, p);
-      HashAddSeparator(&h);
-    }
+        // Set up to rewind allocator for each loop iteration
+        MemAllocLinearScope mem_scope(scratch);
 
-    for (const char* p : ctx.m_Files)
+        // Set up context
+        IterContext ctx;
+        ctx.Init(heap, scratch);
+
+        // Get directory data
+        ListDirectory(path, filter, recurse, &ctx, IterContext::Callback);
+
+        // Sort data
+        qsort(ctx.m_Dirs.m_Storage, ctx.m_Dirs.m_Size, sizeof(const char*), IterContext::SortStringPtrs);
+        qsort(ctx.m_Files.m_Storage, ctx.m_Files.m_Size, sizeof(const char*), IterContext::SortStringPtrs);
+
+        // Compute digest
+        for (const char* p : ctx.m_Dirs)
+        {
+          HashAddPath(&h, p);
+          HashAddSeparator(&h);
+        }
+        
+        // Add an extra separator to catch a directory that turned into a file
+        HashAddSeparator(&h);
+
+        for (const char* p : ctx.m_Files)
+        {
+          HashAddPath(&h, p);
+          HashAddSeparator(&h);
+        }
+        
+        ctx.Destroy();
+    }
+    else if (pathInfo.IsFile())
     {
-      HashAddPath(&h, p);
-      HashAddSeparator(&h);
+        HashAddInteger(&h, pathInfo.m_Timestamp);
     }
 
     HashDigest digest;
     HashFinalize(&h, &digest);
 
-    ctx.Destroy();
     return digest;
 }
 

--- a/src/FileSign.cpp
+++ b/src/FileSign.cpp
@@ -95,7 +95,7 @@ void ComputeFileSignature(
     ComputeFileSignatureTimestamp(out, stat_cache, filename, fn_hash);
 }
 
-t2::HashDigest CalculateGlobSignatureFor(const char* path, const char* filter, t2::MemAllocHeap* heap, t2::MemAllocLinear* scratch)
+t2::HashDigest CalculateGlobSignatureFor(const char* path, const char* filter, bool recurse, t2::MemAllocHeap* heap, t2::MemAllocLinear* scratch)
 {
     // Helper for directory iteration + memory allocation of strings.  We need to
     // buffer the filenames as we need them in sorted order to ensure the results
@@ -143,7 +143,7 @@ t2::HashDigest CalculateGlobSignatureFor(const char* path, const char* filter, t
     ctx.Init(heap, scratch);
 
     // Get directory data
-    ListDirectory(path, filter, &ctx, IterContext::Callback);
+    ListDirectory(path, filter, recurse, &ctx, IterContext::Callback);
 
     // Sort data
     qsort(ctx.m_Dirs.m_Storage, ctx.m_Dirs.m_Size, sizeof(const char*), IterContext::SortStringPtrs);

--- a/src/FileSign.hpp
+++ b/src/FileSign.hpp
@@ -23,7 +23,7 @@ void ComputeFileSignature(
   int                 sha_extension_hash_count,
   bool                force_use_timestamp);
 
-  HashDigest CalculateGlobSignatureFor(const char* path, const char* filter, MemAllocHeap* heap, MemAllocLinear* scratch);
+  HashDigest CalculateGlobSignatureFor(const char* path, const char* filter, bool recurse, MemAllocHeap* heap, MemAllocLinear* scratch);
 
   bool ShouldUseSHA1SignatureFor(const char* filename, const uint32_t sha_extension_hashes[], int sha_extension_hash_count);
 

--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -241,7 +241,7 @@ static int LuaListDirectory(lua_State* L)
   // Push file result table on stack
   lua_newtable(L);
 
-  ListDirectory(dir, nullptr, L, OnFileIter);
+  ListDirectory(dir, nullptr, false, L, OnFileIter);
 
   // Sort both tables
   lua_getglobal(L, "table");


### PR DESCRIPTION
Allow a GlobSignature to specify a 'Recursive' parameter, which, if set to 1, will cause the glob to be computed recursively (i.e. processing not just immediate children of the given path, but all descendent files and directories).

This can be combined with the Filter parameter.

The PR also makes the signature account for path existence (triggering a frontend rerun if the path is later created/deleted) and path kind (triggering a frontend rerun if the path is changed from a directory to a file or vice versa).