### PR TITLE
Fix accidental attempt to recurse inside files

### DIFF
--- a/src/FileInfo.cpp
+++ b/src/FileInfo.cpp
@@ -229,7 +229,7 @@ void ListDirectory(
     if (matchesFilter)
         (*callback)(user_data, info, scan_path);
 
-    if (recurse)
+    if (recurse && info.m_Flags & FileInfo::kFlagDirectory)
         ListDirectory(scan_path, filter, recurse, user_data, callback);
         
 	} while (FindNextFileA(h, &find_data));


### PR DESCRIPTION
Windows recursion code wasn't guarded to ensure that we only did it for directories. This resulted in lots of warnings about FindFirstFile failing.