### PR TITLE
Fix generic scanner result length

### DIFF
--- a/src/IncludeScanner.cpp
+++ b/src/IncludeScanner.cpp
@@ -201,6 +201,9 @@ ScanLineGeneric(MemAllocLinear* allocator, const char *start_in, const GenericSc
 				return 0;
 		}
 
+    // start is pointing to the character after the closing separator, so wind it back one
+    start--;
+
     dest->m_IsSystemInclude = '>' == closing_separator;
 	}
 	else
@@ -217,7 +220,7 @@ ScanLineGeneric(MemAllocLinear* allocator, const char *start_in, const GenericSc
     dest->m_IsSystemInclude = bare_is_system;
 	}
 
-	dest->m_StringLen    = (unsigned short) (start - str_start - 1);
+	dest->m_StringLen    = (unsigned short) (start - str_start);
 	dest->m_String       = StrDupN(allocator, str_start, dest->m_StringLen);
 	dest->m_ShouldFollow = keyword->m_ShouldFollow ? true : false;
 	dest->m_Next         = nullptr;


### PR DESCRIPTION
When using the generic (non-cpp) scanner to locate included files, if you don't have separators around your file path, there was an off-by-one bug which resulted in the final character of the path getting chopped off.