### PR TITLE
Fuzzy suggestions for named nodes

### DIFF
--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -540,6 +540,15 @@ static void FindReachableNodes(uint32_t* node_bits, const DagData* dag, const Bu
 //searching in inputs prevents useful single object builds, as the requested object gets found as an input of the linker
 #define SUPPORT_SEARCHING_IN_INPUTS 0
 
+static int stricmp(const char* string1, const char* string2)
+{
+#if defined(TUNDRA_WIN32) 
+  return _stricmp(string1, string2);
+#else
+  return strcasecmp(string1, string2);
+#endif
+}
+
 // Match their source files and output files against the names specified.
 static void FindNodesByName(
     const DagData*          dag,
@@ -564,7 +573,7 @@ static void FindNodesByName(
     // Try all named nodes first
     for (const NamedNodeData& named_node : tuple->m_NamedNodes)
     {
-      if (0 == strcmp(named_node.m_Name, name))
+      if (0 == strcasecmp(named_node.m_Name, name))
       {
         BufferAppendOne(out_nodes, heap, named_node.m_NodeIndex);
         Log(kDebug, "mapped %s to node %d", name, named_node.m_NodeIndex);

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -26,7 +26,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <map>
+#include <vector>
 #include <sstream>
 
 #if ENABLED(TUNDRA_CASE_INSENSITIVE_FILESYSTEM)
@@ -43,7 +43,7 @@
 #endif
 
 #if defined(TUNDRA_WIN32) 
-#define strcasestr  StrStrIA
+#define strncasecmp  _strnicmp
 #endif
 
 namespace t2
@@ -543,6 +543,41 @@ static void FindReachableNodes(uint32_t* node_bits, const DagData* dag, const Bu
   }
 }
 
+static int LevenshteinDistanceNoCase(const char* s, const char* t)
+{
+  int n = strlen(s);
+  int m = strlen(t);
+  
+  if (n == 0)
+    return m;
+  if (m == 0)
+     return n;
+
+  int xSize = n + 1;
+  int ySize = m + 1;
+  int* d = (int*)alloca(xSize * ySize * sizeof(int));
+
+  for (int x = 0; x <= n; x++)
+    d[ySize * x] = x;
+  for (int y = 0; y <= m; y++)
+    d[y] = y;
+
+  for (int y = 1; y <= m; y++)
+  {
+    for (int x = 1; x <= n; x++)
+    {
+      if (tolower(s[x - 1]) == tolower(t[y - 1])) // Case insensitive
+        d[ySize * x + y] = d[ySize * (x - 1) + y - 1];  // no operation
+      else
+        d[ySize * x + y] = std::min(std::min(
+                    d[ySize * (x - 1) + y] + 1,     // a deletion
+                    d[ySize * x + y - 1] + 1),      // an insertion
+                    d[ySize * (x - 1) + y - 1] + 1  // a substitution
+                );
+    }
+  }
+  return d[ySize * n + m];
+}
 
 //searching in inputs prevents useful single object builds, as the requested object gets found as an input of the linker
 #define SUPPORT_SEARCHING_IN_INPUTS 0
@@ -572,42 +607,45 @@ static void FindNodesByName(
     bool foundMatchingPrefix = false;
     bool prefixIsAmbigious = false;
     const NamedNodeData* nodeDataForMatchingPrefix = nullptr;
-    std::map<int, const char*> nodesWithMatchingPrefix;
-    std::map<int, const char*> nodesWithMatchingSubstring;
+    struct StringWithScore
+    {
+      StringWithScore(int _score, const char* _string) : score(_score), string(_string) {}
+      int score;
+      const char* string;
+    };
+    std::vector<StringWithScore> fuzzyMatches;
+    fuzzyMatches.reserve(tuple->m_NamedNodes.GetCount());
     for (const NamedNodeData& named_node : tuple->m_NamedNodes)
     {
-      // Is string contained?
-      const char* strstrResult = strcasestr(named_node.m_Name, name);
-      if (strstrResult)
+      const int distance = LevenshteinDistanceNoCase(named_node.m_Name, name);
+      const int fuzzyMatchLimit = std::max(0, std::min((int)strlen(name) - 2, 4));
+      bool isFuzzyMatch = distance <= fuzzyMatchLimit;
+
+      // Exact match?
+      if (distance == 0)
       {
-        const int lengthDifference = strlen(named_node.m_Name) - strlen(name);
+        if (strcmp(named_node.m_Name, name) != 0)
+          Log(kInfo, "found case insensitive match for %s, mapping to %s", name, named_node.m_Name.Get());
 
-        // Exact match?
-        if (lengthDifference == 0)
+        BufferAppendOne(out_nodes, heap, named_node.m_NodeIndex);
+        Log(kDebug, "mapped %s to node %d", name, named_node.m_NodeIndex);
+        found = true;
+        break;
+      }
+      // Fuzzy match?
+      else if (isFuzzyMatch)
+        fuzzyMatches.emplace_back(distance, named_node.m_Name.Get());
+      // Prefix match?
+      if (strncasecmp(named_node.m_Name, name, strlen(name)) == 0)
+      {
+        prefixIsAmbigious = foundMatchingPrefix;
+        if (!foundMatchingPrefix)
         {
-          if (strcmp(named_node.m_Name, name) != 0)
-            Log(kInfo, "found case insensitive match for %s, mapping to %s", name, named_node.m_Name.Get());
-
-          BufferAppendOne(out_nodes, heap, named_node.m_NodeIndex);
-          Log(kDebug, "mapped %s to node %d", name, named_node.m_NodeIndex);
-          found = true;
-          break;
+          foundMatchingPrefix = true;
+          nodeDataForMatchingPrefix = &named_node;
         }
-
-        // Prefix match?
-        else if (strstrResult == named_node.m_Name)
-        {
-          if (foundMatchingPrefix)
-            prefixIsAmbigious = true;
-          else
-          {
-            foundMatchingPrefix = true;
-            nodeDataForMatchingPrefix = &named_node;
-          }
-          nodesWithMatchingPrefix.insert(std::make_pair(lengthDifference, named_node.m_Name.Get()));
-        }
-        else
-          nodesWithMatchingSubstring.insert(std::make_pair(lengthDifference, named_node.m_Name.Get()));
+        if (!isFuzzyMatch)
+          fuzzyMatches.emplace_back(strlen(named_node.m_Name) - strlen(name), named_node.m_Name.Get());
       }
     }
 
@@ -648,18 +686,16 @@ static void FindNodesByName(
     if (!found)
     {
       std::stringstream errorOutput;
-      errorOutput << "unable to map " << name << " to any named node or input/output file\n";
-      if (!nodesWithMatchingPrefix.empty() || !nodesWithMatchingSubstring.empty())
+      errorOutput << "unable to map " << name << " to any named node or input/output file";
+      if (!fuzzyMatches.empty())
       {
-        errorOutput << "maybe you meant:\n";
-        for (const auto& match : nodesWithMatchingPrefix)
-          errorOutput << "- " << match.second << "\n";
-        for (const auto& match : nodesWithMatchingSubstring)
-          errorOutput << "- " << match.second << "\n";
+        std::sort(fuzzyMatches.begin(), fuzzyMatches.end(), [](const StringWithScore& a, const StringWithScore& b) { return a.score < b.score; });
+        errorOutput << "\nmaybe you meant:\n";
+        for (int i=0; i<fuzzyMatches.size() - 1; ++i)
+          errorOutput << "- " << fuzzyMatches[i].string << "\n";
+        errorOutput << "- " << fuzzyMatches[fuzzyMatches.size() - 1].string;
       }
-      auto errorString = errorOutput.str();
-      errorString.pop_back(); // Remove trailing newline.
-      Croak(errorString.c_str());
+      Croak(errorOutput.str().c_str());
     }
   }
 }


### PR DESCRIPTION
* matching of named nodes is now case insensitive
* if there is only one possible named node that the input is a prefix of, this node will be used. Completion event will print out a warning.
(e.g. if there is a named node `node` and `note`, `nod` will complete to `node`, whereas `no` will do nothing).
* if there is no unique match, tundra now suggests close matches and all named nodes to which the given string is a prefix (but still fails as usual)