### PR TITLE
Don't delete Windows reparse points/symlinks

### DIFF
--- a/src/FileInfo.hpp
+++ b/src/FileInfo.hpp
@@ -14,6 +14,7 @@ struct FileInfo
     kFlagError        = 1 << 1,
     kFlagFile         = 1 << 2,
     kFlagDirectory    = 1 << 3,
+    kFlagSymlink      = 1 << 4,  // also a junction on Windows
     kFlagDirty        = 1 << 30  // used by stat cache
   };
 
@@ -24,6 +25,7 @@ struct FileInfo
   bool Exists()      const { return 0 != (kFlagExists & m_Flags); }
   bool IsFile()      const { return 0 != (kFlagFile & m_Flags); }
   bool IsDirectory() const { return 0 != (kFlagDirectory & m_Flags); }
+  bool IsSymlink()   const { return 0 != (kFlagSymlink & m_Flags); }
 };
 
 FileInfo GetFileInfo(const char* path);


### PR DESCRIPTION
RemoveDirectoryA will nuke them even if the target is not empty.
Tundra doesn't create them, so if we ever see one, we just leave it
alone.