### PR TITLE
Fix targetdir output registration to use correct paths

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,10 +6,15 @@
       {
         "label": "bee debug-deploy",
         "type": "shell",
-        "command": "bee.exe debug-deploy",
         "group": {
           "kind": "build",
           "isDefault": true
+        },
+        "windows":{
+          "command": "bee.exe debug-deploy"
+        },
+        "osx":{
+          "command": "mono bee.exe debug-deploy"
         }
       }
     ]

--- a/Build.bee.cs
+++ b/Build.bee.cs
@@ -85,13 +85,13 @@ class Build
         Backend.Current.AddAliasDependency($"{name}", file);
     }
 
+    static string DirNameForConfig(NativeProgramConfiguration config) => $"{config.Platform.Name}-{config.ToolChain.Architecture.Name}";
+
     static BuiltNativeProgram SetupSpecificConfiguration(NativeProgram program, NativeProgramConfiguration config,
         NativeProgramFormat format)
     {
         var builtProgram = program.SetupSpecificConfiguration(config, format);
-        var deployedProgram =
-            builtProgram.DeployTo($"build/{config.Platform.Name}-{config.ToolChain.Architecture.Name}/{config.CodeGen}"
-                .ToLower());
+        var deployedProgram = builtProgram.DeployTo($"build/{DirNameForConfig(config)}/{config.CodeGen}".ToLower());
         RegisterAlias($"{program.Name}", config, deployedProgram.Path);
         return deployedProgram;
     }
@@ -215,13 +215,13 @@ class Build
             }
 
             var configFile = new NPath("bee_config.json").MakeAbsolute();
-            if (config.CodeGen == CodeGen.Debug && HostPlatform.IsWindows && configFile.FileExists())
+            if (config.CodeGen == CodeGen.Debug && config.Platform == Platform.HostPlatform && configFile.FileExists())
             {
                 JObject configObject = JObject.Parse(configFile.ReadAllText());
                 var unityCheckout = (string)configObject["unityCheckout"];
                 if (unityCheckout != null)
                 {
-                    var deployDir = new NPath(unityCheckout).Combine(@"External\tundra\builds\build\windows-x86_64\master\");
+                    var deployDir = new NPath(unityCheckout).Combine($"External/tundra/builds/build/{DirNameForConfig(config).ToLower()}/master/");
                     var alias = "debug-deploy";
                     Console.WriteLine($"Setting up {alias} alias to {deployDir}");
                     Backend.Current.AddAliasDependency(alias, tundra.DeployTo(deployDir).Path);

--- a/src/DynamicOutputDirectories.cpp
+++ b/src/DynamicOutputDirectories.cpp
@@ -35,11 +35,15 @@ void InitializeDynamicOutputDirectories(int workerThreadCount)
 
 struct Context
 {
+    const char* m_BasePath;
+    size_t m_BasePathLength;
     SinglyLinkedPathList* m_List;
     MemAllocLinear* m_Allocator;
 
-    Context(MemAllocLinear* allocator, SinglyLinkedPathList* list)
+    Context(const char* basePath, MemAllocLinear* allocator, SinglyLinkedPathList* list)
     {
+        m_BasePath = basePath;
+        m_BasePathLength = strlen(m_BasePath);
         m_Allocator = allocator;
         m_List = list;
     }
@@ -49,7 +53,13 @@ struct Context
         Context& context = *(Context*)ctx;
         SinglyLinkedPathList& result = *context.m_List;
 
-        const char* copiedPath = StrDup(context.m_Allocator,path);
+        size_t pathLength = strlen(path);
+
+        char* copiedPath = LinearAllocateArray<char>(context.m_Allocator, context.m_BasePathLength + 2 + pathLength);
+        memcpy(copiedPath, context.m_BasePath, context.m_BasePathLength);
+        copiedPath[context.m_BasePathLength] = '/';
+        memcpy(copiedPath + context.m_BasePathLength + 1, path, pathLength);
+        copiedPath[context.m_BasePathLength + pathLength + 1] = 0;
 
         SinglyLinkedPathListEntry* newEntry = LinearAllocate<SinglyLinkedPathListEntry>(context.m_Allocator);
         newEntry->next = result.head;
@@ -69,7 +79,7 @@ SinglyLinkedPathList* AllocateEmptyPathList(int threadIndex)
 
 void AppendDirectoryListingToList(const char* directoryToList, int threadIndex, SinglyLinkedPathList& appendToList)
 {
-    Context ctx(&s_State.m_PerThreadLinearAllocators[threadIndex], &appendToList);
+    Context ctx(directoryToList, &s_State.m_PerThreadLinearAllocators[threadIndex], &appendToList);
     ListDirectory(directoryToList, "*", true, &ctx, Context::Callback);
 }
 


### PR DESCRIPTION
Targetdir outputs were being stored relative to the targetdir itself, rather than relative to the build root, which was breaking up-to-date-outputs detection (and causing test failures).

Also, improve the debug-deploy stuff and vscode config to work on OSX as well.