### PR TITLE
Fix long path support

### DIFF
--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -41,6 +41,7 @@
 
 #if defined(TUNDRA_WIN32)
 static double s_PerfFrequency;
+const wchar_t g_LongPathPrefix[k_LongPathPrefixLength] = { L'\\', L'\\', L'?', L'\\' };
 #endif
 
 static bool DebuggerAttached()
@@ -411,7 +412,12 @@ bool MakeDirectory(const char *path)
     if (isalpha(path[0]) && 0 == memcmp(&path[1], ":\\\0", 3))
         return true;
 
-    if (!CreateDirectoryA(path, NULL))
+    const int wideStringLength = MultiByteToWideChar(CP_UTF8, 0, path, -1, NULL, 0);
+    wchar_t* widePath = static_cast<wchar_t*>(alloca(sizeof(wchar_t) * (wideStringLength + k_LongPathPrefixLength + 1)));
+    wcsncpy(widePath, g_LongPathPrefix, k_LongPathPrefixLength);
+    MultiByteToWideChar(CP_UTF8, 0, path, -1, widePath + k_LongPathPrefixLength, wideStringLength);
+
+    if (!CreateDirectoryW(widePath, NULL))
     {
         switch (GetLastError())
         {

--- a/src/Common.hpp
+++ b/src/Common.hpp
@@ -40,6 +40,10 @@
 
 #define TD_ALIGN(v, alignment) (((v) + (alignment)-1) & ~((alignment)-1))
 
+#if TUNDRA_WIN32
+const int k_LongPathPrefixLength = 4;
+extern const wchar_t g_LongPathPrefix[k_LongPathPrefixLength];
+#endif
 
 
 void InitCommon(void);


### PR DESCRIPTION
Use wide-character versions of the Win32 APIs for creating directories and statting files, prefixing the special \\?\ code which allows these APIs to operate on long paths (>MAX_PATH characters).