### PR TITLE
Bump max thread count to 128. 

### DIFF
--- a/src/BuildQueue.hpp
+++ b/src/BuildQueue.hpp
@@ -19,7 +19,7 @@ struct DriverOptions;
 
 enum
 {
-    kMaxBuildThreads = 64
+    kMaxBuildThreads = 128
 };
 
 struct BuildQueueConfig


### PR DESCRIPTION
These new threadrippers are a reality for some!

Looking at the possible downsides, there's only two arrays that are sized by max thread count. We never walk over "all of them", just walking up to the thread count.