### PR TITLE
Actually auto-detect more than 64 CPU cores on windows

### DIFF
--- a/Build.bee.cs
+++ b/Build.bee.cs
@@ -47,7 +47,7 @@ class Build
 
             // We can enable this by committing valgrind to the repository or uploading a public stevedore artifact.
             this.Defines.Add("USE_VALGRIND=NO");
-            this.Defines.Add(IsWindows, "WIN32_LEAN_AND_MEAN", "NOMINMAX", "WINVER=0x0600", "_WIN32_WINNT=0x0600");
+            this.Defines.Add(IsWindows, "WIN32_LEAN_AND_MEAN", "NOMINMAX", "WINVER=0x0601", "_WIN32_WINNT=0x0601"); // allow using Windows 7+ APIs
             this.DynamicLinkerSettingsForMsvc().Add(linker => linker.WithSubSystemType(SubSystemType.Console));
 
             //the toolchain we currently use on linux has a many bugs when combining -g and -flto. turn off -g for linux in master builds for now

--- a/Build.bee.cs
+++ b/Build.bee.cs
@@ -58,22 +58,29 @@ class Build
 
     static NPath GenerateGitFile()
     {
-        var result = Shell.Execute("git for-each-ref --count 1 --format \"%(objectname):%(refname:short)\"");
-        if (!result.Success)
-            return null;
+        try
+        {
+            var result = Shell.Execute("git for-each-ref --count 1 --format \"%(objectname):%(refname:short)\"");
+            if (!result.Success)
+                return null;
 
-        var matches = Regex.Matches(result.StdOut, @"(\w+?):(.+)");
-        if (matches.Count == 0)
-            return null;
+            var matches = Regex.Matches(result.StdOut, @"(\w+?):(.+)");
+            if (matches.Count == 0)
+                return null;
 
-        var hash = matches[0].Groups[0].Captures[0].Value;
-        var branch = matches[0].Groups[1].Captures[0].Value;
-        var gitRevFile = Configuration.AbsoluteRootArtifactsPath.Combine($"generated/git_rev.c");
-        gitRevFile.WriteAllText($@"
-            const char g_GitVersion[] = ""${hash}"";
-            const char g_GitBranch[]  = ""${branch}"";
-        ");
-        return gitRevFile;
+            var hash = matches[0].Groups[0].Captures[0].Value;
+            var branch = matches[0].Groups[1].Captures[0].Value;
+            var gitRevFile = Configuration.AbsoluteRootArtifactsPath.Combine($"generated/git_rev.c");
+            gitRevFile.WriteAllText($@"
+                const char g_GitVersion[] = ""${hash}"";
+                const char g_GitBranch[]  = ""${branch}"";
+            ");
+            return gitRevFile;
+        }
+        catch (Exception) // e.g. Win32Exception if git is not found
+        {
+            return null;
+        }
     }
 
     static void RegisterAlias(string name, NativeProgramConfiguration config, NPath file)

--- a/src/BuildQueue.hpp
+++ b/src/BuildQueue.hpp
@@ -19,7 +19,7 @@ struct DriverOptions;
 
 enum
 {
-    kMaxBuildThreads = 64
+    kMaxBuildThreads = 128
 };
 
 struct BuildQueueConfig

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -472,9 +472,14 @@ bool MakeDirectory(const char *path)
 int GetCpuCount()
 {
 #if defined(TUNDRA_WIN32)
-    SYSTEM_INFO si;
-    GetSystemInfo(&si);
-    return (int)si.dwNumberOfProcessors;
+    // Note: GetSystemInfo dwNumberOfProcessors is capped at 64, even if CPU has more.
+    // GetActiveProcessorCount with ALL_PROCESSOR_GROUPS will return all of them.
+    // Each process is still limited to only using 64 CPUs by default, so our own worker
+    // threads will be running on max 64 cores, if we create more. However our own worker threads
+    // are not doing "expensive work"; the expensive work is build processes launched by them.
+    // So Should Be Fine.
+    DWORD cpus = GetActiveProcessorCount(ALL_PROCESSOR_GROUPS);
+    return (int)cpus;
 #else
     long nprocs_max = sysconf(_SC_NPROCESSORS_CONF);
     if (nprocs_max < 0)


### PR DESCRIPTION
Continuation of #70 -- turns out normally most Windows APIs only say "up to 64 threads".

Also here:
- Allow building tundra even if "git" is not on the path,
- Bump up minspec to Windows 7 (`GetActiveProcessorCount` is only since 7)