### PR TITLE
New debug deploy mechanism

### DIFF
--- a/Build.bee.cs
+++ b/Build.bee.cs
@@ -221,13 +221,16 @@ class Build
             if (config.CodeGen == CodeGen.Debug && config.Platform == Platform.HostPlatform && configFile.FileExists())
             {
                 JObject configObject = JObject.Parse(configFile.ReadAllText());
-                var unityCheckout = (string)configObject["unityCheckout"];
-                if (unityCheckout != null)
+                var externalDeployPaths = (JArray)configObject["externalDeployPaths"];
+                if (externalDeployPaths != null)
                 {
-                    var deployDir = new NPath(unityCheckout).Combine($"External/tundra/builds/build/{DirNameForConfig(config).ToLower()}/master/");
                     var alias = "debug-deploy";
-                    Console.WriteLine($"Setting up {alias} alias to {deployDir}");
-                    Backend.Current.AddAliasDependency(alias, tundra.DeployTo(deployDir).Path);
+
+                    foreach (NPath path in externalDeployPaths.Select(t => new NPath(t.ToString())))
+                    {
+                        Console.WriteLine($"Setting up {alias} alias to {path}");
+                        Backend.Current.AddAliasDependency(alias, tundra.DeployTo(path).Path);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Now that Tundra is acquired from Stevedore in the main Unity repo, the old deploy path doesn't do anything useful. Change it so we can specify multiple paths to deploy to, so that we overwrite the Stevedore artifacts that were already unpacked.