### PR TITLE
Add SilenceOnSuccess flag

### DIFF
--- a/src/DagData.hpp
+++ b/src/DagData.hpp
@@ -95,7 +95,11 @@ struct DagNode
 
         kFlagIsWriteTextFileAction = 1 << 4,
         kFlagAllowUnwrittenOutputFiles = 1 << 5,
-        kFlagBanContentDigestForInputs = 1 << 6
+        kFlagBanContentDigestForInputs = 1 << 6,
+
+        // Only print console output if the command failed.
+        // Useful for overly noisy actions.
+        kFlagSilenceOnSuccess = 1 << 7,
     };
 
     FrozenString m_Action;

--- a/src/DagGenerator.cpp
+++ b/src/DagGenerator.cpp
@@ -460,6 +460,7 @@ static bool WriteNodes(
         flags |= GetNodeFlag(node, "AllowUnexpectedOutput", Frozen::DagNode::kFlagAllowUnexpectedOutput, false);
         flags |= GetNodeFlag(node, "AllowUnwrittenOutputFiles", Frozen::DagNode::kFlagAllowUnwrittenOutputFiles, false);
         flags |= GetNodeFlag(node, "BanContentDigestForInputs", Frozen::DagNode::kFlagBanContentDigestForInputs, false);
+        flags |= GetNodeFlag(node, "SilenceOnSuccess", Frozen::DagNode::kFlagSilenceOnSuccess, false);
 
         if (writetextfile_payload != nullptr)
             flags |= Frozen::DagNode::kFlagIsWriteTextFileAction;

--- a/src/RunAction.cpp
+++ b/src/RunAction.cpp
@@ -87,6 +87,7 @@ NodeBuildResult::Enum RunAction(BuildQueue *queue, ThreadState *thread_state, Ru
 {
     const Frozen::DagNode *node_data = node->m_DagNode;
     const bool isWriteFileAction = node->m_DagNode->m_Flags & Frozen::DagNode::kFlagIsWriteTextFileAction;
+    const bool silenceOnSuccess = node->m_DagNode->m_Flags & Frozen::DagNode::kFlagSilenceOnSuccess;
     const char *cmd_line = node_data->m_Action;
 
     if (!isWriteFileAction && (!cmd_line || cmd_line[0] == '\0'))
@@ -232,6 +233,11 @@ NodeBuildResult::Enum RunAction(BuildQueue *queue, ThreadState *thread_state, Ru
         {
             last_cmd_line = cmd_line;
             result = ExecuteProcess(cmd_line, env_count, env_vars, thread_state->m_Queue->m_Config.m_Heap, job_id, false, SlowCallback, &slowCallbackData);
+
+            if (silenceOnSuccess && result.m_ReturnCode == 0) {
+                result.m_OutputBuffer.cursor = 0;
+            }
+
             passedOutputValidation = ValidateExecResultAgainstAllowedOutput(&result, node_data);
         }
 


### PR DESCRIPTION
This flag allows you to hide the output from an action if it succeeded,
which is useful for overly noisy commands.