### PR TITLE
Swallow action output that does not contain non-newline characters

### DIFF
--- a/src/OutputValidation.cpp
+++ b/src/OutputValidation.cpp
@@ -30,7 +30,7 @@ ValidationResult ValidateExecResultAgainstAllowedOutput(ExecResult *result, cons
 
     const char *buffer = result->m_OutputBuffer.buffer;
     if (!HasAnyNonNewLine(buffer))
-        return ValidationResult::Pass;
+        return ValidationResult::SwallowStdout;
 
     for (int i = 0; i != allowed.GetCount(); i++)
     {


### PR DESCRIPTION
Normally, we would swallow output if allowedOuputSubstrings were specified for an action (and one of the patterns matched). But there was a corner case for output that only contains newlines, then we would not check the patterns and output was not being swallowed.

Let's just go ahead and always swallow this corner-case output.