### PR TITLE
FileInfo should return info about symlinks on unix, not their targets

### DIFF
--- a/src/FileInfo.cpp
+++ b/src/FileInfo.cpp
@@ -51,15 +51,10 @@ FileInfo GetFileInfo(const char *path)
     uint32_t flags = 0;
 
 #if defined(TUNDRA_UNIX)
+
     if (0 != lstat(path, &stbuf))
         goto Failure;
 
-    if ((stbuf.st_mode & S_IFMT) == S_IFLNK)
-    {
-        flags |= FileInfo::kFlagSymlink;
-        if (0 != stat(path, &stbuf))
-            goto Failure;
-    }
 #elif defined(TUNDRA_WIN32)
 
     DWORD attrs;
@@ -98,6 +93,8 @@ FileInfo GetFileInfo(const char *path)
         flags |= FileInfo::kFlagDirectory;
     else if ((stbuf.st_mode & S_IFMT) == S_IFREG)
         flags |= FileInfo::kFlagFile;
+    else if ((stbuf.st_mode & S_IFMT) == S_IFLNK)
+        flags |= FileInfo::kFlagSymlink;
 
     result.m_Flags = flags;
     // Do not allow directories to expose real timestamps, as it's not reliable behaviour across platforms


### PR DESCRIPTION
On unix, FileInfo currently returns struct stat information about the target, with FileInfo::kFlagSymlink set. This can cause AllowUnwrittenOutputFiles verification errors, because it checks the mtimes against the symlink with its target, which is unrelated.