### PR TITLE
Fix windows longpath support

### DIFF
--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -402,6 +402,8 @@ std::wstring ToWideString(const char* input)
 
 bool ConvertToLongPath(std::wstring* path)
 {
+    if (path == nullptr) return false;
+
     if (IsNormalized(*path))
     {
         WIN32_FILE_ATTRIBUTE_DATA data;

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -387,7 +387,7 @@ void ResolvePrefixPath(char* buf, wchar_t** prefix, bool* resolveFullPath) {
 
 errno_t ConvertToUnicode(char const* path, wchar_t** widePath) {
     // Get required buffer size to convert to Unicode
-    int wideLen = MultiByteToWideChar(CP_ACP,
+    int wideLen = MultiByteToWideChar(CP_UTF8,
         MB_ERR_INVALID_CHARS,
         path, -1,
         NULL, 0);
@@ -397,7 +397,7 @@ errno_t ConvertToUnicode(char const* path, wchar_t** widePath) {
 
     *widePath = static_cast<wchar_t*>(::malloc(wideLen * sizeof(wchar_t)));
 
-    int result = MultiByteToWideChar(CP_ACP,
+    int result = MultiByteToWideChar(CP_UTF8,
         MB_ERR_INVALID_CHARS,
         path, -1,
         *widePath, wideLen);
@@ -428,12 +428,12 @@ errno_t ResolveFullPath(wchar_t* widePath, wchar_t** resolvedPath) {
 // Win32 API calls know that is can skip the validation checks against
 // MAX_PATH, but this also causes issues where if there is a ".." in the
 // path (including paths that have the drive letter attached e.g D:\Foo\..\Thing)
-// windows doesn't properly collapse the path, and the underlying kernal call doesn't
+// windows doesn't properly collapse the path, and the underlying kernel call doesn't
 // know how to resolve the ".." properly and functions such as CreateDirectoryW
 // will fail with "ERROR_INVALID_NAME" which in this case will cause tundra to fail
 // when it tries to copy over files that are relative and long paths.
 // See https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#maximum-path-length-limitation
-// Also this code could be way less gross if we could use std::wstring
+// Also this code could be way less gross if we could use std::wstring (andrews)
 wchar_t* ConvertToLongPath(char const* path, errno_t& err) {
     if ((path == NULL) || (path[0] == '\0')) {
         err = ENOENT;

--- a/src/Common.hpp
+++ b/src/Common.hpp
@@ -9,6 +9,8 @@
 #if defined(_MSC_VER)
 #include <malloc.h>
 #include <intrin.h>
+#include <string>
+#include <wchar.h>
 #elif defined(TUNDRA_WIN32_MINGW)
 #include <malloc.h>
 #elif defined(TUNDRA_UNIX)
@@ -41,7 +43,17 @@
 #define TD_ALIGN(v, alignment) (((v) + (alignment)-1) & ~((alignment)-1))
 
 #if TUNDRA_WIN32
-wchar_t* ConvertToLongPath(char const* path, errno_t & err);
+#include <codecvt>
+#include <locale>
+
+using convert_t = std::codecvt_utf8<wchar_t>;
+inline std::wstring ToWideString(std::string str)
+{
+    std::wstring_convert<convert_t, wchar_t> strconverter;
+    return strconverter.from_bytes(str);
+}
+
+bool ConvertToLongPath(std::wstring* path);
 #endif
 
 

--- a/src/Common.hpp
+++ b/src/Common.hpp
@@ -41,7 +41,7 @@
 #define TD_ALIGN(v, alignment) (((v) + (alignment)-1) & ~((alignment)-1))
 
 #if TUNDRA_WIN32
-int LongPathToPrefixedWidePath(const char* path, wchar_t* buffer, int bufferSize);
+wchar_t* ConvertToLongPath(char const* path, errno_t & err);
 #endif
 
 

--- a/src/Common.hpp
+++ b/src/Common.hpp
@@ -43,16 +43,7 @@
 #define TD_ALIGN(v, alignment) (((v) + (alignment)-1) & ~((alignment)-1))
 
 #if TUNDRA_WIN32
-#include <codecvt>
-#include <locale>
-
-using convert_t = std::codecvt_utf8<wchar_t>;
-inline std::wstring ToWideString(std::string str)
-{
-    std::wstring_convert<convert_t, wchar_t> strconverter;
-    return strconverter.from_bytes(str);
-}
-
+std::wstring ToWideString(const char* input);
 bool ConvertToLongPath(std::wstring* path);
 #endif
 

--- a/src/FileInfo.cpp
+++ b/src/FileInfo.cpp
@@ -67,15 +67,14 @@ FileInfo GetFileInfo(const char *path)
     if (strlen(path) >= MAX_PATH)
     {
         //// To work around maximum path length limitations on Windows, we have to use the wide-character version of the API, with a special prefix
-        errno_t err;
-        wchar_t* widePath = ConvertToLongPath(path, err);
-        if (err != ERROR_SUCCESS)
+        std::wstring widePath(ToWideString(path));
+        if (!ConvertToLongPath(&widePath))
             goto Failure;
 
-        if (0 != _wstat64(widePath, &stbuf))
+        if (0 != _wstat64(widePath.c_str(), &stbuf))
             goto Failure;
 
-        attrs = GetFileAttributesW(widePath);
+        attrs = GetFileAttributesW(widePath.c_str());
         if (attrs == INVALID_FILE_ATTRIBUTES)
             goto Failure;
     }

--- a/src/FileInfo.cpp
+++ b/src/FileInfo.cpp
@@ -66,10 +66,11 @@ FileInfo GetFileInfo(const char *path)
 
     if (strlen(path) >= MAX_PATH)
     {
-        // To work around maximum path length limitations on Windows, we have to use the wide-character version of the API, with a special prefix
-        const int widePathLength = LongPathToPrefixedWidePath(path, NULL, 0);
-        wchar_t* widePath = static_cast<wchar_t*>(alloca(sizeof(wchar_t) * widePathLength));
-        LongPathToPrefixedWidePath(path, widePath, widePathLength);
+        //// To work around maximum path length limitations on Windows, we have to use the wide-character version of the API, with a special prefix
+        errno_t err;
+        wchar_t* widePath = ConvertToLongPath(path, err);
+        if (err != ERROR_SUCCESS)
+            goto Failure;
 
         if (0 != _wstat64(widePath, &stbuf))
             goto Failure;

--- a/src/FileInfo.cpp
+++ b/src/FileInfo.cpp
@@ -64,29 +64,18 @@ FileInfo GetFileInfo(const char *path)
 
     DWORD attrs;
 
-    if (strlen(path) >= MAX_PATH)
-    {
-        //// To work around maximum path length limitations on Windows, we have to use the wide-character version of the API, with a special prefix
-        std::wstring widePath(ToWideString(path));
-        if (!ConvertToLongPath(&widePath))
-            goto Failure;
+    std::wstring widePath(ToWideString(path));
+    //// To work around maximum path length limitations on Windows, we have to use the wide-character version of the API, with a special prefix
+    if (!ConvertToLongPath(&widePath))
+        goto Failure;
 
-        if (0 != _wstat64(widePath.c_str(), &stbuf))
-            goto Failure;
+    if (0 != _wstat64(widePath.c_str(), &stbuf))
+        goto Failure;
 
-        attrs = GetFileAttributesW(widePath.c_str());
-        if (attrs == INVALID_FILE_ATTRIBUTES)
-            goto Failure;
-    }
-    else
-    {
-        if (0 != _stat64(path, &stbuf))
-            goto Failure;
-
-        attrs = GetFileAttributesA(path);
-        if (attrs == INVALID_FILE_ATTRIBUTES)
-            goto Failure;
-    }
+    attrs = GetFileAttributesW(widePath.c_str());
+    if (attrs == INVALID_FILE_ATTRIBUTES)
+        goto Failure;
+  
 
     if ((attrs & FILE_ATTRIBUTE_REPARSE_POINT) != 0)
         flags |= FileInfo::kFlagSymlink;

--- a/unittest/Test_Win32_LongPaths.cpp
+++ b/unittest/Test_Win32_LongPaths.cpp
@@ -1,0 +1,76 @@
+#include "TestHarness.hpp"
+#include "Common.hpp"
+
+#if defined(TUNDRA_WIN32)
+#include <Windows.h>
+
+
+TEST(Win32_LongPaths, ShortRelativePath_IsReferencedDirectly)
+{
+    wchar_t srcPath[] = L"this\\path\\is\\relative";
+
+    wchar_t buf[MAX_PATH];
+    const size_t srcLength = ::GetFullPathNameW(srcPath, MAX_PATH, buf, nullptr);
+
+    std::wstring dstPath = srcPath;
+
+    ASSERT_TRUE(ConvertToLongPath(&dstPath));
+    ASSERT_EQ(srcLength, dstPath.length());
+    ASSERT_STREQ(buf, dstPath.c_str());
+}
+
+TEST(Win32_LongPaths, Null_Path_Fail)
+{
+    ASSERT_FALSE(ConvertToLongPath(nullptr));
+}
+
+TEST(Win32_LongPaths, Zero_Length)
+{
+    std::wstring dstPath;
+
+    ASSERT_TRUE(ConvertToLongPath(&dstPath));
+    ASSERT_EQ(0, dstPath.length());
+}
+
+TEST(Win32_LongPaths, LongRelativePath_Resolved)
+{
+    wchar_t srcPath[] = L"C:\\long\\path\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\..\\abcdefghijklmnopqrstuvwxyz\\..\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz";
+    wchar_t resultPath[] = L"\\\\?\\C:\\long\\path\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz";
+
+    const size_t srcLength = ::GetFullPathNameW(srcPath, 0, nullptr, nullptr);
+    ASSERT_GT(srcLength, MAX_PATH);
+
+    std::wstring dstPath = srcPath;
+
+    ASSERT_TRUE(ConvertToLongPath(&dstPath));
+    ASSERT_EQ(wcslen(resultPath), dstPath.length());
+    ASSERT_STREQ(dstPath.c_str(), resultPath);
+}
+
+TEST(Win32_LongPaths, LongAbsolutePath_WithExtendedPrefix)
+{
+    wchar_t srcPath[] = L"C:\\long\\path\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz";
+    const size_t srcLength = _countof(srcPath);
+    ASSERT_GT(srcLength, MAX_PATH);
+
+    std::wstring dstPath = srcPath;
+
+    ASSERT_TRUE(ConvertToLongPath(&dstPath));
+    ASSERT_GT(dstPath.length(), srcLength);
+    ASSERT_STREQ(dstPath.c_str(), L"\\\\?\\C:\\long\\path\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz");
+}
+
+TEST(Win32_LongPaths, LongUNCPath_WithExtendedUNCPrefix)
+{
+    wchar_t srcPath[] = L"\\\\MYMACHINE\\C\\long\\path\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz";
+    const size_t srcLength = _countof(srcPath);
+    ASSERT_GT(srcLength, MAX_PATH);
+
+    std::wstring dstPath = srcPath;
+
+    ASSERT_TRUE(ConvertToLongPath(&dstPath));
+    ASSERT_GT(dstPath.length(), srcLength);
+    ASSERT_STREQ(dstPath.c_str(), L"\\\\?\\UNC\\MYMACHINE\\C\\long\\path\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz");
+}
+
+#endif


### PR DESCRIPTION
This PR adds proper Long Path support, that works for the different use cases: 

```
MakeDirectory("C:\\Users\\foo\\source\\repos\\Builds\\");
MakeDirectory("C:\\Users\\foo\\source\\repos\\..\\Builds\\");
MakeDirectory("\\\\?\\C:\\Users\\foo\\source\\repos\\..\\Builds\\");
MakeDirectory("..\\..\\Build\\");
MakeDirectory("..\\..\\BuildssldkfjsdawdawdawxwxwxwxwxwxwxwxwxwxwxwxwxwxwxdawdawdfsdfsdfsdfsdfsdfsdfsdldkjflskjdflskjdflksjdflksjdfBuildssldkfjsldkjflskjdflskjdflksjdflksjdfBuildssldkfjsldkjflskjdflskjdflksjdflksjdfBuildssldkfjsldkjflskjdflskjdflksjdflksjdf\\");
```

These use cases are now properly supported, where before relative paths were just broken, and not properly being resolved which is required when you use the long path prefix. 

The usage of std::wstring makes the code far less complex and more clear whats going on, it also prevents memory leaks or just general bad pointer foo. This code is not in the most critical perf path so I didn't feel like it needed to rely on the underlying LinearAllocator as the standard std::allocator is just wrapping malloc anyways and these are all temp strings anyways and I don't feel like there would be a lot of benefit using the LinearAllocator 