### PR TITLE
Fix instability when writing over outputs that were only just modified

### DIFF
--- a/src/FileInfo.cpp
+++ b/src/FileInfo.cpp
@@ -49,7 +49,6 @@ FileInfo GetFileInfo(const char *path)
 #endif
 
     uint32_t flags = 0;
-    uint64_t mtime;
 
 #if defined(TUNDRA_UNIX)
     if (0 != lstat(path, &stbuf))
@@ -100,15 +99,9 @@ FileInfo GetFileInfo(const char *path)
     else if ((stbuf.st_mode & S_IFMT) == S_IFREG)
         flags |= FileInfo::kFlagFile;
 
-    mtime = stbuf.st_mtime;
-#if defined(TUNDRA_UNIX)
-    // Use nanosecond resolution
-    mtime = mtime * 1000000000ul + stbuf.st_mtim.tv_nsec;
-#endif
-
     result.m_Flags = flags;
     // Do not allow directories to expose real timestamps, as it's not reliable behaviour across platforms
-    result.m_Timestamp = (flags & FileInfo::kFlagDirectory) ? kDirectoryTimestamp : mtime;
+    result.m_Timestamp = (flags & FileInfo::kFlagDirectory) ? kDirectoryTimestamp : stbuf.st_mtime;
     result.m_Size = stbuf.st_size;
 
     return result;

--- a/src/FileInfo.cpp
+++ b/src/FileInfo.cpp
@@ -49,6 +49,7 @@ FileInfo GetFileInfo(const char *path)
 #endif
 
     uint32_t flags = 0;
+    uint64_t mtime;
 
 #if defined(TUNDRA_UNIX)
     if (0 != lstat(path, &stbuf))
@@ -99,9 +100,15 @@ FileInfo GetFileInfo(const char *path)
     else if ((stbuf.st_mode & S_IFMT) == S_IFREG)
         flags |= FileInfo::kFlagFile;
 
+    mtime = stbuf.st_mtime;
+#if defined(TUNDRA_UNIX)
+    // Use nanosecond resolution
+    mtime = mtime * 1000000000ul + stbuf.st_mtim.tv_nsec;
+#endif
+
     result.m_Flags = flags;
     // Do not allow directories to expose real timestamps, as it's not reliable behaviour across platforms
-    result.m_Timestamp = (flags & FileInfo::kFlagDirectory) ? kDirectoryTimestamp : stbuf.st_mtime;
+    result.m_Timestamp = (flags & FileInfo::kFlagDirectory) ? kDirectoryTimestamp : mtime;
     result.m_Size = stbuf.st_size;
 
     return result;

--- a/src/RunAction.cpp
+++ b/src/RunAction.cpp
@@ -28,7 +28,11 @@
 #include <stdarg.h>
 #include <algorithm>
 #include <stdio.h>
-
+#if defined(TUNDRA_WIN32)
+#include <sys/utime.h>
+#else
+#include <utime.h>
+#endif
 
 struct SlowCallbackData
 {
@@ -220,11 +224,26 @@ NodeBuildResult::Enum RunAction(BuildQueue *queue, ThreadState *thread_state, Ru
 
         bool allowUnwrittenOutputFiles = (node_data->m_Flags & Frozen::DagNode::kFlagAllowUnwrittenOutputFiles);
         if (!allowUnwrittenOutputFiles)
+        {
+            uint64_t current_time = time(NULL);
+
             for (int i = 0; i < n_outputs; i++)
             {
                 FileInfo info = GetFileInfo(node_data->m_OutputFiles[i].m_Filename);
                 pre_timestamps[i] = info.m_Timestamp;
+
+                if (info.m_Timestamp == current_time)
+                {
+                    // This file has been created so recently that a very fast action might not
+                    // actually be recognised as modifying the timestamp on the file. To avoid
+                    // this, backdate the file by a second, so that any actual activity will definitely
+                    // cause the timestamp to change.
+                    struct utimbuf times;
+                    pre_timestamps[i] = times.actime = times.modtime = current_time - 1;
+                    utime(node_data->m_OutputFiles[i].m_Filename, &times);
+                }
             }
+        }
 
         if (isWriteFileAction)
             result = WriteTextFile(node_data->m_Action, node_data->m_OutputFiles[0].m_Filename, thread_state->m_Queue->m_Config.m_Heap);


### PR DESCRIPTION
We are only working with file timestamps at 1sec resolution, so that means that if, in the space of one second, we modify an output file, and then run a build which modifies that output file again.. then the build will fail to identify that the file was actually modified, because the timestamp will not change. This seems to be a problem on BKAs (which execute faster than Katana) for some of the tests we have which execute two builds back-to-back.

To solve the problem, when we are capturing timestamps prior to running an action, we check for any files that already have a timestamp matching the current time - and if we find any, we 'backdate' them, changing the last-modified time to be back by 1 second. When the action then runs, if it actually modifies the output, we should be guaranteed a difference of at least 1 second before and after the action.