### PR TITLE
Unbreak windows builds

### DIFF
--- a/src/FileInfo.cpp
+++ b/src/FileInfo.cpp
@@ -82,8 +82,10 @@ FileInfo GetFileInfo(const char *path)
         flags |= FileInfo::kFlagDirectory;
     else if ((stbuf.st_mode & S_IFMT) == S_IFREG)
         flags |= FileInfo::kFlagFile;
+#ifdef S_IFLNK
     else if ((stbuf.st_mode & S_IFMT) == S_IFLNK)
         flags |= FileInfo::kFlagSymlink;
+#endif
 
     result.m_Flags = flags;
     // Do not allow directories to expose real timestamps, as it's not reliable behaviour across platforms


### PR DESCRIPTION
The regular windows10 toolchain doesn't define the S_IFLNK macro even though it supports symlinks, so ifdef this reference.