### PR TITLE
Fixing bugs with longpath support/createdirectory

### DIFF
--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -367,6 +367,8 @@ double TimerDiffSeconds(uint64_t start, uint64_t end)
 
 #if defined(TUNDRA_WIN32)
 
+#define MAX_PATH_CREATEDIR 248
+
 const wchar_t  ExtendedPrefix[] = L"\\\\?\\";
 const wchar_t  DevicePathPrefix[] = L"\\\\.\\";
 const wchar_t  UNCExtendedPathPrefix[] = L"\\\\?\\UNC\\";
@@ -423,14 +425,17 @@ bool ConvertToLongPath(std::wstring* path)
     }
 
     std::wstring str;
-    if (size < MAX_PATH)
+    // This is 248 instead of 260 which is MAX_PATH because according to MSDN:
+    // For the ANSI version of CreateDirectoryW, there is a default string
+    // size limit for paths of 248 characters (MAX_PATH - enough room for a 8.3 filename).
+    if (size < MAX_PATH_CREATEDIR)
     {
         str.assign(buf);
     }
     else
     {
         str.resize(size + wcslen(UNCExtendedPathPrefix), 0);
-        size = ::GetFullPathNameW(path->c_str(), size, const_cast<LPWSTR>(str.data()), nullptr);
+        size = ::GetFullPathNameW(path->c_str(), str.length(), const_cast<LPWSTR>(str.data()), nullptr);
 
         if (size == 0)
         {

--- a/unittest/Test_Win32_LongPaths.cpp
+++ b/unittest/Test_Win32_LongPaths.cpp
@@ -47,6 +47,21 @@ TEST(Win32_LongPaths, LongRelativePath_Resolved)
     ASSERT_STREQ(dstPath.c_str(), resultPath);
 }
 
+TEST(Win32_LongPaths, LongRelativePath_CreateDirectoryWSize)
+{
+    wchar_t srcPath[] = L"C:\\longs\\paths\\AppData\\Local\\Temp\\BeeTest\\BackendTests_Tundra.OutputWithLongPath_IsNotReb-n511prpy\\15charactername\\15charactername\\15charactername\\15charactername\\15charactername\\15charactername\\15charactername\\15charactername\\15charactername\\15charactername";
+    wchar_t resultPath[] = L"\\\\?\\C:\\longs\\paths\\AppData\\Local\\Temp\\BeeTest\\BackendTests_Tundra.OutputWithLongPath_IsNotReb-n511prpy\\15charactername\\15charactername\\15charactername\\15charactername\\15charactername\\15charactername\\15charactername\\15charactername\\15charactername\\15charactername";
+
+    const size_t srcLength = ::GetFullPathNameW(srcPath, 0, nullptr, nullptr);
+    ASSERT_EQ(srcLength, 259); // this must be greater than 248 but less than MAX_PATH
+
+    std::wstring dstPath = srcPath;
+
+    ASSERT_TRUE(ConvertToLongPath(&dstPath));
+    ASSERT_EQ(wcslen(resultPath), dstPath.length());
+    ASSERT_STREQ(dstPath.c_str(), resultPath);
+}
+
 TEST(Win32_LongPaths, LongAbsolutePath_WithExtendedPrefix)
 {
     wchar_t srcPath[] = L"C:\\long\\path\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz";


### PR DESCRIPTION
improper size was being passed into GetFullPathNameW and fixed a bug where CreateDirectoryW has a 248 char limit for a path because of a filename potentially being appended to the end according to MSDN, also added a test to cover this case.

https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createdirectoryw