### PR TITLE
most-urgent dependencies go first

### DIFF
--- a/src/BuildLoop.cpp
+++ b/src/BuildLoop.cpp
@@ -93,6 +93,9 @@ int EnqueueNodeWithoutWakingAwaiters(BuildQueue *queue, MemAllocLinear* scratch,
     if (RuntimeNodeIsActive(runtime_node) || runtime_node->m_Finished)
         return 0;
 
+    if (onlyEnqueueIfNotEnqueuedBefore && RuntimeNodeHasEverBeenQueued(runtime_node))
+        return 0;
+
     int runtime_node_index = int(runtime_node - queue->m_Config.m_RuntimeNodes);
 
     BufferAppendOne(&queue->m_WorkStack, queue->m_Config.m_Heap, runtime_node_index);

--- a/src/BuildLoop.cpp
+++ b/src/BuildLoop.cpp
@@ -390,7 +390,7 @@ static RuntimeNode *NextNode(BuildQueue *queue)
 
         if (RuntimeNodeIsActive(runtime_node) || runtime_node->m_Finished)
         {
-            //this can happen in legit situations. we allow nodes to appear on the workstack once. This happens in situations where
+            //this can happen in legit situations. we allow nodes to appear on the workstack more than once. This happens in situations where
             //a node gets queued as not-very-urgent (aka at the end of a dependency list). But later, the same node is also a dependency of something
             //that was queued at the top of the stack. In this case, we enqueue it again, ensuring it gets processed as fast as possible. We do not
             //bother deleting the older entry from the workstack, and instead have this check & continue.

--- a/src/BuildLoop.cpp
+++ b/src/BuildLoop.cpp
@@ -79,7 +79,7 @@ static int EnqueueNodeListReversedWithoutWakingAwaiters(BuildQueue* queue, MemAl
 
     //we enqueue dependency lists in reverse. because our semantics say that the most urgent dependencies are in the list first, it's important that they
     //end up on the top of the workstack, so they'll be processed first.
-    for(int i=nodesToEnqueue.GetCount(); i>=0; i++)
+    for(int i=nodesToEnqueue.GetCount(); i-- > 0;)
     {
         int32_t depDagIndex = nodesToEnqueue[i];
         enqueue_count += EnqueueNodeWithoutWakingAwaiters(queue, scratch, &queue->m_Config.m_RuntimeNodes[depDagIndex], enqueingNode);

--- a/src/BuildLoop.hpp
+++ b/src/BuildLoop.hpp
@@ -6,4 +6,4 @@ struct BuildQueue;
 
 
 void BuildLoop(ThreadState *thread_state);
-int EnqueueNodeWithoutWakingAwaiters(BuildQueue *queue, MemAllocLinear* scratch, RuntimeNode *runtime_node, RuntimeNode* queueing_node);
+int EnqueueNodeWithoutWakingAwaiters(BuildQueue *queue, MemAllocLinear* scratch, RuntimeNode *runtime_node, RuntimeNode* queueing_node, bool onlyEnqueueIfNotEnqueuedBefore);

--- a/src/BuildQueue.cpp
+++ b/src/BuildQueue.cpp
@@ -168,7 +168,7 @@ BuildResult::Enum BuildQueueBuild(BuildQueue *queue, MemAllocLinear* scratch)
     for (auto requestedNode:  queue->m_Config.m_RequestedNodes)
     {
         RuntimeNode *runtime_node = runtime_nodes + requestedNode;
-        EnqueueNodeWithoutWakingAwaiters(queue, queue->m_Config.m_LinearAllocator, runtime_node, nullptr);
+        EnqueueNodeWithoutWakingAwaiters(queue, queue->m_Config.m_LinearAllocator, runtime_node, nullptr, false);
     }
 
     CondBroadcast(&queue->m_WorkAvailable);

--- a/src/BuildQueue.hpp
+++ b/src/BuildQueue.hpp
@@ -91,10 +91,7 @@ struct BuildQueue
     Mutex m_BuildFinishedMutex;
     bool m_BuildFinishedConditionalVariableSignaled;
 
-    int32_t *m_Queue;
-    uint32_t m_QueueCapacity;
-    uint32_t m_QueueReadIndex;
-    uint32_t m_QueueWriteIndex;
+    Buffer<int32_t> m_WorkStack;
     BuildQueueConfig m_Config;
 
     BuildResult::Enum m_FinalBuildResult;

--- a/src/NodeResultPrinting.cpp
+++ b/src/NodeResultPrinting.cpp
@@ -27,6 +27,7 @@ struct NodeResultPrintData
     const bool *untouched_outputs;
     const char *output_buffer;
     int processed_node_count;
+    int amount_of_nodes_ever_queued;
     MessageStatusLevel::Enum status_level;
     int return_code;
     bool was_signalled;
@@ -498,6 +499,7 @@ void PrintNodeResult(
     data.validation_result = validationResult;
     data.untouched_outputs = untouched_outputs;
     data.processed_node_count = processedNodeCount;
+    data.amount_of_nodes_ever_queued = queue->m_AmountOfNodesEverQueued;
     data.status_level = failed ? MessageStatusLevel::Failure : MessageStatusLevel::Success;
 
     data.return_code = was_preparation_error ? 1 : result->m_ReturnCode;
@@ -527,6 +529,12 @@ void PrintNodeResult(
 
         JsonWriteKeyName(&msg, "msg");
         JsonWriteValueString(&msg, "noderesult");
+
+        JsonWriteKeyName(&msg, "processed_node_count");
+        JsonWriteValueInteger(&msg, data.processed_node_count);
+
+        JsonWriteKeyName(&msg, "amount_of_nodes_ever_queued");
+        JsonWriteValueInteger(&msg, data.amount_of_nodes_ever_queued);
 
         JsonWriteKeyName(&msg, "annotation");
         JsonWriteValueString(&msg, node_data->m_Annotation);

--- a/src/NodeResultPrinting.cpp
+++ b/src/NodeResultPrinting.cpp
@@ -537,7 +537,7 @@ void PrintNodeResult(
         JsonWriteKeyName(&msg, "exitcode");
         JsonWriteValueInteger(&msg, result->m_ReturnCode);
 
-        if (failed && data.output_buffer)
+        if (data.output_buffer)
         {
             JsonWriteKeyName(&msg, "stdout");
             JsonWriteValueString(&msg, data.output_buffer);


### PR DESCRIPTION
tundra's scheduling was not optimized for any specific order. This PR changes it to ensure that all scheduling happens in favor of the "most urgent" dependencies, which it expects to be provided first in the dependency list.

Also replace a lowlevel buildqueue with pointers and read/write index, into a simpler Buffer<> stack.