### PR TITLE
Move inspect datafile functionality into main binary

### DIFF
--- a/Build.bee.cs
+++ b/Build.bee.cs
@@ -156,13 +156,6 @@ class Build
         tundraUnitTestProgram.IncludeDirectories.Add($"{UnitTestSourceFolder}/googletest/googletest");
         tundraUnitTestProgram.IncludeDirectories.Add($"{UnitTestSourceFolder}/googletest/googletest/include");
 
-        var inspectProram = new TundraNativeProgram("tundra2-inspect")
-        {
-            Libraries = {tundraLibraryProgram},
-            Sources = {SourceFolder.Combine("InspectMain.cpp")}
-        };
-
-
 
         // setup build targets
         var toolChains = new ToolChain[]
@@ -195,8 +188,6 @@ class Build
             var tundraUnitTestExecutable =
                 (Executable) SetupSpecificConfiguration(tundraUnitTestProgram, config, toolchain.ExecutableFormat);
             projectFileBuilders[tundraUnitTestProgram].AddProjectConfiguration(config, tundraUnitTestExecutable);
-
-            SetupSpecificConfiguration(inspectProram, config, toolchain.ExecutableFormat);
 
             if (Bee.PramBinding.Pram.CanLaunch(toolchain.Platform, toolchain.Architecture))
             {

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -71,6 +71,7 @@ void DriverOptionsInit(DriverOptions *self)
 #if defined(TUNDRA_WIN32)
     self->m_RunUnprotected = true;
 #endif
+    self->m_Inspect = false;
 }
 
 

--- a/src/Driver.hpp
+++ b/src/Driver.hpp
@@ -29,6 +29,7 @@ struct DriverOptions
     bool m_SilenceIfPossible;
     bool m_DontReusePreviousResults;
     bool m_DebugSigning;
+    bool m_Inspect;
     int m_IdentificationColor;
     int m_VisualMaxNodes;
 #if defined(TUNDRA_WIN32)

--- a/src/Inspect.cpp
+++ b/src/Inspect.cpp
@@ -4,6 +4,7 @@
 #include "ScanData.hpp"
 #include "DigestCache.hpp"
 #include "MemoryMappedFile.hpp"
+#include "Inspect.hpp"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -313,11 +314,11 @@ static void DumpDigestCache(const Frozen::DigestCacheState *data)
 const Frozen::Dag* dag_data = nullptr;
 const Frozen::DagDerived* dag_derived_data = nullptr;
 
-int main(int argc, char *argv[])
+int inspect(int num_files, char *files[])
 {
-    for (int i=1; i!= argc; i++)
+    for (int i=0; i < num_files; i++)
     {
-        const char* fn = argv[i];
+        const char* fn = files[i];
         MemoryMappedFile f;
         MmapFileInit(&f);
         MmapFileMap(&f, fn);
@@ -332,7 +333,7 @@ int main(int argc, char *argv[])
                 if (dag_data->m_MagicNumber != Frozen::Dag::MagicNumber)
                 {
                     fprintf(stderr, "%s: bad magic number\n", fn);
-                    exit(1);
+                    return 1;
                 }
             }
             else if (0 == strcmp(suffix, ".dag_derived"))
@@ -341,7 +342,7 @@ int main(int argc, char *argv[])
                 if (dag_derived_data->m_MagicNumber != Frozen::DagDerived::MagicNumber)
                 {
                     fprintf(stderr, "%s: bad magic number\n", fn);
-                    exit(1);
+                    return 1;
                 }
             }
             else if (0 == strcmp(suffix, ".state"))
@@ -394,7 +395,7 @@ int main(int argc, char *argv[])
     if (dag_derived_data != nullptr)
     {
         DumpDagDerived(dag_derived_data, dag_data);
-        exit(0);
+        return 0;
     }
     if (dag_data != nullptr)
     {

--- a/src/Inspect.hpp
+++ b/src/Inspect.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+int inspect(int num_files, char *files[]);

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -12,6 +12,7 @@
 #include "RemoveStaleOutputs.hpp"
 #include "AllBuiltNodes.hpp"
 #include "ReportIncludes.hpp"
+#include "Inspect.hpp"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -67,6 +68,7 @@ static const struct OptionTemplate
 #if defined(TUNDRA_WIN32)
     {'U', "unprotected", OptionType::kBool, offsetof(DriverOptions, m_RunUnprotected), "Run unprotected (same process group - for debugging)"},
 #endif
+    {'X', "inspect", OptionType::kBool, offsetof(DriverOptions, m_Inspect), "Inspect the following data files, then exit."},
     };
 
 static int AssignOptionValue(char *option_base, const OptionTemplate *templ, const char *value, bool is_short)
@@ -265,6 +267,12 @@ int main(int argc, char *argv[])
     }
 
     DriverInitializeTundraFilePaths(&options);
+
+    if (options.m_Inspect)
+    {
+        return inspect(argc, argv);
+    }
+
 #if defined(TUNDRA_WIN32)
     if (!options.m_RunUnprotected && nullptr == getenv("_TUNDRA2_PARENT_PROCESS_HANDLE"))
     {


### PR DESCRIPTION
This is not yet tested, build seems to build. Pushed for early review.

I guess we should drop the tundra2-inspect binary completely? And the command line args probably need adjustment. Opinions welcome.