### PR TITLE
exit early if there's an unreadable state file

### DIFF
--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -141,7 +141,8 @@ bool DriverInitData(Driver *self)
     {
         // We cannot recognise stale output files in this case. If we
         // continue we might produce incorrect build results.
-        Log(kError, "Previous state file exists, but it is unreadable - please remove the artifacts directory before rebuilding");
+        Log(kError, "Unreadable state file \"%s\" - possibly created by an incompatible version of Tundra. You can fix this by removing the build output directory before rebuilding.",
+            self->m_DagData->m_StateFileName.Get());
         return false;
     }
 


### PR DESCRIPTION
If there is an unreadable state file, then tundra won't be able to perform the stale output removal step, and we might produce incorrect build results.

This can happen when the tundra binary is updated to a version with a different magic number (tundra can only read frozen data files with the same magic number).

Instead of quietly producing incorrect results, we should exit early with an error message advising the user to clean the artifacts directory and then to rebuild.