### PR TITLE
Stale output bug

### DIFF
--- a/src/Inspect.cpp
+++ b/src/Inspect.cpp
@@ -88,6 +88,7 @@ static void DumpDag(const Frozen::Dag *data)
 {
     int node_count = data->m_NodeCount;
     printf("magic number: 0x%08x\n", data->m_MagicNumber);
+    printf("hashed identifier: 0x%08x\n", data->m_HashedIdentifier);
     printf("node count: %u\n", node_count);
     for (int i = 0; i < node_count; ++i)
     {
@@ -253,6 +254,9 @@ static void DumpState(const Frozen::AllBuiltNodes *data)
         printf("  aux outputs:\n");
         for (const FrozenFileAndHash& fileAndHash : node.m_AuxOutputFiles)
             printf("    (0x%08x) %s\n", fileAndHash.m_FilenameHash, fileAndHash.m_Filename.Get());
+        printf("  m_DagsWeHaveSeenThisNodeInPreviously:\n");
+        for (const auto& dagsWeHaveSeenThisNodeInPreviously : node.m_DagsWeHaveSeenThisNodeInPreviously)
+            printf("    0x%08x\n", dagsWeHaveSeenThisNodeInPreviously);
 
         printf("  input files:\n");
         for (int i=0; i!=node.m_InputFiles.GetCount(); i++)

--- a/src/RemoveStaleOutputs.cpp
+++ b/src/RemoveStaleOutputs.cpp
@@ -127,6 +127,13 @@ void RemoveStaleOutputs(Driver *self)
         if (wasChild)
             return;
 
+        //It's possible and valid for this file to not exist. We write entries into the buildstate for nodes that failed. For nodes that failed
+        //we do not know if they did or did not happen to write their output files. We still want to delete potentially stray files should that
+        //node be removed from the dag in the future. It's also possible that the output files didn't get written. in that case we should not try
+        //to remove it, and not report it as being removed.
+        if (!GetFileInfo(path).IsFile())
+            return;
+
         if (!HashSetLookup(&nuke_table, path_hash, path))
         {
             HashSetInsert(&nuke_table, path_hash, path);

--- a/src/RemoveStaleOutputs.cpp
+++ b/src/RemoveStaleOutputs.cpp
@@ -127,6 +127,7 @@ void RemoveStaleOutputs(Driver *self)
         if (wasChild)
             return;
 
+        add_parent_directories_to_nuke_table(path);
         //It's possible and valid for this file to not exist. We write entries into the buildstate for nodes that failed. For nodes that failed
         //we do not know if they did or did not happen to write their output files. We still want to delete potentially stray files should that
         //node be removed from the dag in the future. It's also possible that the output files didn't get written. in that case we should not try
@@ -138,8 +139,6 @@ void RemoveStaleOutputs(Driver *self)
         {
             HashSetInsert(&nuke_table, path_hash, path);
         }
-
-        add_parent_directories_to_nuke_table(path);
     };
 
 


### PR DESCRIPTION
fix a bug where tundra would report over and over about its futile attempts to delete a file that doesn't exist.