### PR TITLE
Refactoring to support more action strategies

### DIFF
--- a/src/Actions.cpp
+++ b/src/Actions.cpp
@@ -25,6 +25,10 @@ namespace ActionType {
 
     const char* ToString(Enum value)
     {
-        return kCommandNames[static_cast<size_t>(value)];
+        size_t index = static_cast<size_t>(value);
+        if (index >= kNumCommandNames)
+            return kCommandNames[kUnknown];
+
+        return kCommandNames[index];
     }
 }

--- a/src/Actions.cpp
+++ b/src/Actions.cpp
@@ -1,0 +1,30 @@
+#include "Actions.hpp"
+#include <string.h>
+
+constexpr const char* kCommandNames[] = {
+    "<unknown>",
+    "RunShellCommand",
+    "WriteTextFile"
+};
+constexpr size_t kNumCommandNames = sizeof(kCommandNames) / sizeof(kCommandNames[0]);
+
+namespace ActionType {
+
+    Enum FromString(const char* name)
+    {
+        for (size_t i = 0; i < kNumCommandNames; ++i)
+        {
+            if (strcmp(name, kCommandNames[i]) == 0)
+            {
+                return static_cast<Enum>(i);
+            }
+        }
+
+        return ActionType::kUnknown;
+    }
+
+    const char* ToString(Enum value)
+    {
+        return kCommandNames[static_cast<size_t>(value)];
+    }
+}

--- a/src/Actions.cpp
+++ b/src/Actions.cpp
@@ -1,6 +1,7 @@
 #include "Actions.hpp"
 #include <string.h>
 
+// This order should match the order of enum members in Actions.hpp
 constexpr const char* kCommandNames[] = {
     "<unknown>",
     "RunShellCommand",

--- a/src/Actions.hpp
+++ b/src/Actions.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "Common.hpp"
+
+namespace ActionType
+{
+    enum Enum : uint8_t
+    {
+    	kUnknown = 0,
+        kRunShellCommand = 1,
+        kWriteTextFile = 2
+    };
+
+    Enum FromString(const char* name);
+    const char* ToString(Enum value);
+}

--- a/src/Actions.hpp
+++ b/src/Actions.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Common.hpp"
+#include <stdint.h>
 
 namespace ActionType
 {

--- a/src/Actions.hpp
+++ b/src/Actions.hpp
@@ -6,7 +6,7 @@ namespace ActionType
 {
     enum Enum : uint8_t
     {
-    	kUnknown = 0,
+        kUnknown = 0,
         kRunShellCommand = 1,
         kWriteTextFile = 2
     };

--- a/src/AllBuiltNodes.cpp
+++ b/src/AllBuiltNodes.cpp
@@ -82,9 +82,16 @@ static void save_node_sharedcode(Frozen::BuiltNodeResult::Enum builtNodeResult, 
     for (int32_t i = 0; i < file_count; ++i)
         WriteFrozenFileAndHashIntoBuiltNodesStream(src_node->m_AuxOutputFiles[i]);
 
-    BinarySegmentWritePointer(segments.built_nodes, BinarySegmentPosition(segments.string));
+    if (src_node->m_Action && emitDataForBeeWhy)
+    {
+        BinarySegmentWritePointer(segments.built_nodes, BinarySegmentPosition(segments.string));
+        BinarySegmentWriteStringData(segments.string, src_node->m_Action);
+    }
+    else
+    {
+        BinarySegmentWriteNullPointer(segments.built_nodes);
+    }
 
-    BinarySegmentWriteStringData(segments.string, emitDataForBeeWhy ? src_node->m_Action : "");
 }
 
 

--- a/src/BuildLoop.cpp
+++ b/src/BuildLoop.cpp
@@ -198,7 +198,7 @@ static bool IsNodeCacheableByLeafInputsAndCachingEnabled(BuildQueue* queue, Runt
 {
     if (!queue->m_Config.m_AttemptCacheReads && !queue->m_Config.m_AttemptCacheWrites)
         return false;
-    return 0 != (node->m_DagNode->m_Flags & Frozen::DagNode::kFlagCacheableByLeafInputs);
+    return 0 != (node->m_DagNode->m_FlagsAndActionType & Frozen::DagNode::kFlagCacheableByLeafInputs);
 }
 
 static void AttemptCacheWrite(BuildQueue* queue, ThreadState* thread_state, RuntimeNode* node)

--- a/src/DagData.cpp
+++ b/src/DagData.cpp
@@ -18,7 +18,7 @@ void FindDependentNodesFromRootIndex_IncludingSelf_NotRecursingIntoCacheableNode
         const int dag_bit = 1 << (dag_index & 31);
         if (0 == (node_visited_bits[dag_word] & dag_bit))
         {
-            if ((dagNode.m_Flags & Frozen::DagNode::kFlagCacheableByLeafInputs) && !isRootSearchNode)
+            if ((dagNode.m_FlagsAndActionType & Frozen::DagNode::kFlagCacheableByLeafInputs) && !isRootSearchNode)
             {
                 if (dependenciesThatAreCacheableThemselves)
                     BufferAppendOne(dependenciesThatAreCacheableThemselves, heap, dag_index);

--- a/src/DagData.hpp
+++ b/src/DagData.hpp
@@ -82,7 +82,7 @@ struct DagNode
     enum
     {
         // Bottom 8 bits are reserved for the action type
-    	kFlagActionTypeMask = (1 << 8) - 1,
+        kFlagActionTypeMask = (1 << 8) - 1,
     	
         // Set in m_Flags if it is safe to overwrite the output files in place.  If
         // this flag is not present, the build system will remove the output files

--- a/src/DagData.hpp
+++ b/src/DagData.hpp
@@ -81,28 +81,33 @@ struct DagNode
 {
     enum
     {
+        // Bottom 8 bits are reserved for the action type
+    	kFlagActionTypeMask = (1 << 8) - 1,
+    	
         // Set in m_Flags if it is safe to overwrite the output files in place.  If
         // this flag is not present, the build system will remove the output files
         // before running the action. This is useful to prevent tools that
         // sometimes misbehave in the presence of old output files. ar is a good
         // example.
-        kFlagOverwriteOutputs = 1 << 0,
+        kFlagOverwriteOutputs = 1 << 8,
 
         // Keep output files even if the build fails. Useful mostly to retain files
         // for incremental linking.
-        kFlagPreciousOutputs = 1 << 1,
+        kFlagPreciousOutputs = 1 << 9,
 
         //if not set, we fail the build when a command prints anything unexpected to stdout or stderr
-        kFlagAllowUnexpectedOutput = 1 << 3,
+        kFlagAllowUnexpectedOutput = 1 << 10,
 
-        kFlagIsWriteTextFileAction = 1 << 4,
-        kFlagAllowUnwrittenOutputFiles = 1 << 5,
-        kFlagBanContentDigestForInputs = 1 << 6,
+        kFlagAllowUnwrittenOutputFiles = 1 << 11,
+        kFlagBanContentDigestForInputs = 1 << 12,
 
-        kFlagCacheableByLeafInputs = 1 << 7
+        kFlagCacheableByLeafInputs = 1 << 13
     };
 
-    FrozenString m_Action;
+    union {
+        FrozenString m_Action;
+        FrozenString m_WriteTextPayload;
+    };
     FrozenString m_Annotation;
     FrozenArray<int32_t> m_ToBuildDependencies;
     FrozenArray<int32_t> m_ToUseDependencies;
@@ -121,7 +126,7 @@ struct DagNode
     FrozenArray<DagFileSignature> m_FileSignatures;
     FrozenArray<DagGlobSignature> m_GlobSignatures;
     FrozenArray<FrozenFileAndHash> m_CachingInputIgnoreList;
-    uint32_t m_Flags;
+    uint32_t m_FlagsAndActionType;
     uint32_t m_OriginalIndex;
     uint32_t m_DagNodeIndex;
 };
@@ -137,7 +142,7 @@ struct SharedResourceData
 
 struct Dag
 {
-    static const uint32_t MagicNumber = 0x24efa246 ^ kTundraHashMagic;
+    static const uint32_t MagicNumber = 0x24efa247 ^ kTundraHashMagic;
 
     uint32_t m_MagicNumber;
 

--- a/src/DagDerivedCompiler.cpp
+++ b/src/DagDerivedCompiler.cpp
@@ -73,7 +73,7 @@ struct CompileDagDerivedWorker
 
     static bool IsLeafInputCacheable(const Frozen::DagNode& dagNode)
     {
-        return HasFlag(dagNode.m_Flags, Frozen::DagNode::kFlagCacheableByLeafInputs);
+        return HasFlag(dagNode.m_FlagsAndActionType, Frozen::DagNode::kFlagCacheableByLeafInputs);
     }
 
     void WriteIndexArray(BinarySegment* segment, Buffer<int32_t>& buffer)

--- a/src/FileInfo.cpp
+++ b/src/FileInfo.cpp
@@ -87,6 +87,9 @@ FileInfo GetFileInfo(const char *path)
         flags |= FileInfo::kFlagSymlink;
 #endif
 
+    if ((stbuf.st_mode & S_IWRITE) == 0)
+      flags |= FileInfo::kFlagReadOnly;
+
     result.m_Flags = flags;
     // Do not allow directories to expose real timestamps, as it's not reliable behaviour across platforms
     result.m_Timestamp = (flags & FileInfo::kFlagDirectory) ? kDirectoryTimestamp : stbuf.st_mtime;

--- a/src/FileInfo.hpp
+++ b/src/FileInfo.hpp
@@ -11,6 +11,7 @@ struct FileInfo
         kFlagFile = 1 << 2,
         kFlagDirectory = 1 << 3,
         kFlagSymlink = 1 << 4, // also a junction on Windows
+        kFlagReadOnly     = 1 << 5,
         kFlagDirty = 1 << 30   // used by stat cache
     };
 
@@ -22,6 +23,7 @@ struct FileInfo
     bool IsFile() const { return 0 != (kFlagFile & m_Flags); }
     bool IsDirectory() const { return 0 != (kFlagDirectory & m_Flags); }
     bool IsSymlink() const { return 0 != (kFlagSymlink & m_Flags); }
+    bool IsReadOnly()  const { return 0 != (kFlagReadOnly & m_Flags); }
 };
 
 FileInfo GetFileInfo(const char *path);

--- a/src/InputSignature.cpp
+++ b/src/InputSignature.cpp
@@ -389,6 +389,8 @@ static bool CalculateInputSignature(BuildQueue* queue, ThreadState* thread_state
         });
     }
 
+    HashAddInteger(&sighash, (uint8_t)dagnode->m_FlagsAndActionType & Frozen::DagNode::kFlagActionTypeMask);
+
     for (const FrozenString &input : dagnode->m_AllowedOutputSubstrings)
         HashAddString(&sighash, (const char *)input);
 

--- a/src/InputSignature.cpp
+++ b/src/InputSignature.cpp
@@ -328,7 +328,7 @@ static bool CalculateInputSignature(BuildQueue* queue, ThreadState* thread_state
     if (scanner)
         HashSetInit(&node->m_ImplicitInputs, queue->m_Config.m_Heap);
 
-    bool force_use_timestamp = dagnode->m_Flags & Frozen::DagNode::kFlagBanContentDigestForInputs;
+    bool force_use_timestamp = dagnode->m_FlagsAndActionType & Frozen::DagNode::kFlagBanContentDigestForInputs;
 
     // Roll back scratch allocator after all file scans
     MemAllocLinearScope alloc_scope(&thread_state->m_ScratchAlloc);
@@ -392,8 +392,8 @@ static bool CalculateInputSignature(BuildQueue* queue, ThreadState* thread_state
     for (const FrozenString &input : dagnode->m_AllowedOutputSubstrings)
         HashAddString(&sighash, (const char *)input);
 
-    HashAddInteger(&sighash, (dagnode->m_Flags & Frozen::DagNode::kFlagAllowUnexpectedOutput) ? 1 : 0);
-    HashAddInteger(&sighash, (dagnode->m_Flags & Frozen::DagNode::kFlagAllowUnwrittenOutputFiles) ? 1 : 0);
+    HashAddInteger(&sighash, (dagnode->m_FlagsAndActionType & Frozen::DagNode::kFlagAllowUnexpectedOutput) ? 1 : 0);
+    HashAddInteger(&sighash, (dagnode->m_FlagsAndActionType & Frozen::DagNode::kFlagAllowUnwrittenOutputFiles) ? 1 : 0);
 
     HashFinalize(&sighash, &node->m_CurrentInputSignature);
     return true;

--- a/src/InputSignature.cpp
+++ b/src/InputSignature.cpp
@@ -103,7 +103,7 @@ static void ReportChangedInputFiles(JsonWriter *msg, const FrozenArray<Frozen::N
 
 static void ReportValueWithOptionalTruncation(JsonWriter *msg, const char *keyName, const char *truncatedKeyName, const FrozenString &value)
 {
-    size_t len = strlen(value);
+    size_t len = value ? strlen(value) : 0;
     const size_t maxLen = KB(64);
     JsonWriteKeyName(msg, keyName);
     JsonWriteValueString(msg, value, maxLen);

--- a/src/Inspect.cpp
+++ b/src/Inspect.cpp
@@ -5,6 +5,7 @@
 #include "DigestCache.hpp"
 #include "MemoryMappedFile.hpp"
 #include "Inspect.hpp"
+#include "Actions.hpp"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -30,9 +31,9 @@ static void DumpDagDerived(const Frozen::DagDerived* data, const Frozen::Dag* da
         if (dag)
         {
             printf("  flags:");
-            if (dagNode->m_Flags & Frozen::DagNode::kFlagCacheableByLeafInputs)
+            if (dagNode->m_FlagsAndActionType & Frozen::DagNode::kFlagCacheableByLeafInputs)
                 printf("    kFlagCacheableByLeafInputs");
-           if (dagNode->m_Flags & Frozen::DagNode::kFlagOverwriteOutputs)
+           if (dagNode->m_FlagsAndActionType & Frozen::DagNode::kFlagOverwriteOutputs)
                 printf("    kFlagOverwriteOutputs");
         }
 
@@ -101,11 +102,12 @@ static void DumpDag(const Frozen::Dag *data)
 
         printf("  guid: %s\n", digest_str);
         printf("  flags:");
-        if (node.m_Flags & Frozen::DagNode::kFlagPreciousOutputs)
+        if (node.m_FlagsAndActionType & Frozen::DagNode::kFlagPreciousOutputs)
             printf(" precious");
-        if (node.m_Flags & Frozen::DagNode::kFlagOverwriteOutputs)
+        if (node.m_FlagsAndActionType & Frozen::DagNode::kFlagOverwriteOutputs)
             printf(" overwrite");
 
+        printf("\n  type: %s\n", ActionType::ToString(static_cast<ActionType::Enum>(node.m_FlagsAndActionType & Frozen::DagNode::kFlagActionTypeMask)));
         printf("\n  action: %s\n", node.m_Action.Get());
         printf("  annotation: %s\n", node.m_Annotation.Get());
 

--- a/src/JsonWriter.hpp
+++ b/src/JsonWriter.hpp
@@ -32,3 +32,4 @@ void JsonWriteValueInteger(JsonWriter *writer, int64_t value);
 void JsonWriteNewline(JsonWriter *writer);
 
 void JsonWriteToFile(JsonWriter *writer, FILE *fp);
+const char* JsonWriteToString(JsonWriter* writer, MemAllocLinear* heap);

--- a/src/LeafInputSignature.cpp
+++ b/src/LeafInputSignature.cpp
@@ -215,7 +215,7 @@ void PrintLeafInputSignature(BuildQueue* buildQueue, const char* outputFile)
 {
     const Frozen::DagNode& dagNode = buildQueue->m_Config.m_DagNodes[buildQueue->m_Config.m_RequestedNodes[0]];
 
-    if (0 == (dagNode.m_Flags & Frozen::DagNode::kFlagCacheableByLeafInputs))
+    if (0 == (dagNode.m_FlagsAndActionType & Frozen::DagNode::kFlagCacheableByLeafInputs))
     {
         Croak("Requested node %s is not cacheable by leaf inputs\n", dagNode.m_Annotation.Get());
     }

--- a/src/LeafInputSignatureOffline.cpp
+++ b/src/LeafInputSignatureOffline.cpp
@@ -36,7 +36,7 @@ HashDigest CalculateLeafInputHashOffline(MemAllocHeap* heap, const Frozen::Dag* 
         for (auto& f: dagNode.m_OutputFiles)
             HashAddString(ingredient_stream, &hashState, "output", f.m_Filename.Get());
 
-        int relevantFlags = dagNode.m_Flags & ~Frozen::DagNode::kFlagCacheableByLeafInputs;
+        int relevantFlags = dagNode.m_FlagsAndActionType & ~(Frozen::DagNode::kFlagCacheableByLeafInputs | Frozen::DagNode::kFlagActionTypeMask);
 
         //if our flags are completely default, let's not add them to the stream, it makes the ingredient stream easier
         //to parse/compare for a human.

--- a/src/OutputValidation.cpp
+++ b/src/OutputValidation.cpp
@@ -23,7 +23,7 @@ static bool HasAnyNonNewLine(const char *buffer)
 ValidationResult::Enum ValidateExecResultAgainstAllowedOutput(ExecResult *result, const Frozen::DagNode *node_data)
 {
     auto &allowed = node_data->m_AllowedOutputSubstrings;
-    bool allowOutput = node_data->m_Flags & Frozen::DagNode::kFlagAllowUnexpectedOutput;
+    bool allowOutput = node_data->m_FlagsAndActionType & Frozen::DagNode::kFlagAllowUnexpectedOutput;
 
     if (allowOutput && allowed.GetCount() == 0)
         return ValidationResult::Pass;

--- a/unittest/Test_JsonWrite.cpp
+++ b/unittest/Test_JsonWrite.cpp
@@ -1,0 +1,41 @@
+#include "TestHarness.hpp"
+#include "JsonWriter.hpp"
+#include "MemAllocLinear.hpp"
+#include "MemAllocHeap.hpp"
+
+class JsonWriteTest : public ::testing::Test
+{
+protected:
+  MemAllocHeap heap;
+  MemAllocLinear alloc;
+  MemAllocLinear scratch;
+  char error_msg[1024];
+
+protected:
+  void SetUp() override
+  {
+    HeapInit(&heap);
+    LinearAllocInit(&alloc, &heap, MB(1), "json alloc");
+    LinearAllocInit(&scratch, &heap, MB(1), "json scratch");
+  }
+
+  void TearDown() override
+  {
+    LinearAllocDestroy(&scratch);
+    LinearAllocDestroy(&alloc);
+    HeapDestroy(&heap);
+  }
+
+};
+
+TEST_F(JsonWriteTest, NullString)
+{
+    JsonWriter writer;
+    JsonWriteInit(&writer, &alloc);
+
+    JsonWriteValueString(&writer, nullptr);
+
+    const char* result = JsonWriteToString(&writer, &alloc);
+    ASSERT_STREQ("null", result);
+}
+


### PR DESCRIPTION
In preparation for being able to add more different ways of actually executing a node - both for things like 'copy file' but also for things like 'just launch this executable directly, don't launch it via a shell' - refactor the existing code that deals with regular vs WriteTextFile actions to use an actual 'action type' enumeration, rather than just a single bit flag. This is controlled by an optional `ActionType` property in the JSON - if omitted then it is determined automatically using the same logic as today. This means that there are no Bee-side changes _required_ to go with this Tundra change - we will only need to start changing Bee when we actually want to add more action types and use them.

Also, because a node like CopyFile will not have an action string, harden a few code paths against null action strings: JSON writing a null string value will now produce a `null` literal, input signature components that are null strings will get correctly treated as zero-length, and also saving Bee Why information for nodes with no action will produce a null pointer as expected.

Also, add a 'file is read-only' flag for FileInfo. Useful for producing better error messages in the event that we can't overwrite/delete a file.

I've tested these changes by running the TundraBackend tests locally, and also building the Editor. Everything seems fine.