### PR TITLE
Built-in file copy support

### DIFF
--- a/src/Actions.cpp
+++ b/src/Actions.cpp
@@ -6,7 +6,7 @@ constexpr const char* kCommandNames[] = {
     "<unknown>",
     "RunShellCommand",
     "WriteTextFile",
-    "CopyFile"
+    "CopyFiles"
 };
 constexpr size_t kNumCommandNames = sizeof(kCommandNames) / sizeof(kCommandNames[0]);
 
@@ -71,7 +71,7 @@ ExecResult WriteTextFile(const char* payload, const char* target_file, MemAllocH
 
 #if !defined(TUNDRA_APPLE) && !defined(TUNDRA_WIN32)
 
-ExecResult CopyFile(const char* src_file, const char* target_file, StatCache* stat_cache, MemAllocHeap* heap)
+ExecResult CopyFiles(const FrozenFileAndHash* src_files, const FrozenFileAndHash* target_files, size_t files_count, StatCache* stat_cache, MemAllocHeap* heap)
 {
     ExecResult result;
     memset(&result, 0, sizeof(result));

--- a/src/Actions.cpp
+++ b/src/Actions.cpp
@@ -69,7 +69,7 @@ ExecResult WriteTextFile(const char* payload, const char* target_file, MemAllocH
     return result;
 }
 
-#if !defined(TUNDRA_APPLE) && !defined(TUNDRA_WIN32)
+#if !defined(TUNDRA_APPLE) && !defined(TUNDRA_WIN32) && !defined(TUNDRA_LINUX)
 
 ExecResult CopyFiles(const FrozenFileAndHash* src_files, const FrozenFileAndHash* target_files, size_t files_count, StatCache* stat_cache, MemAllocHeap* heap)
 {

--- a/src/Actions.cpp
+++ b/src/Actions.cpp
@@ -67,3 +67,21 @@ ExecResult WriteTextFile(const char* payload, const char* target_file, MemAllocH
     result.m_ReturnCode = 1;
     return result;
 }
+
+#if !defined(TUNDRA_APPLE) && !defined(TUNDRA_WIN32)
+
+ExecResult CopyFile(const char* src_file, const char* target_file, StatCache* stat_cache, MemAllocHeap* heap)
+{
+    ExecResult result;
+    memset(&result, 0, sizeof(result));
+
+    const char notImplMsg[] = "CopyFile is not implemented yet.";
+
+    result.m_ReturnCode = -1;
+    InitOutputBuffer(&result.m_OutputBuffer, heap);
+    EmitOutputBytesToDestination(&result, notImplMsg, strlen(notImplMsg));
+
+    return result;
+}
+
+#endif

--- a/src/Actions.cpp
+++ b/src/Actions.cpp
@@ -5,7 +5,8 @@
 constexpr const char* kCommandNames[] = {
     "<unknown>",
     "RunShellCommand",
-    "WriteTextFile"
+    "WriteTextFile",
+    "CopyFile"
 };
 constexpr size_t kNumCommandNames = sizeof(kCommandNames) / sizeof(kCommandNames[0]);
 

--- a/src/Actions.cpp
+++ b/src/Actions.cpp
@@ -33,3 +33,37 @@ namespace ActionType {
         return kCommandNames[index];
     }
 }
+
+ExecResult WriteTextFile(const char* payload, const char* target_file, MemAllocHeap* heap)
+{
+    ExecResult result;
+    char tmpBuffer[1024];
+
+    memset(&result, 0, sizeof(result));
+
+    FILE* f = fopen(target_file, "wb");
+    if (!f)
+    {
+        InitOutputBuffer(&result.m_OutputBuffer, heap);
+
+        snprintf(tmpBuffer, sizeof(tmpBuffer), "Error opening for writing the file: %s, error: %s", target_file, strerror(errno));
+        EmitOutputBytesToDestination(&result, tmpBuffer, strlen(tmpBuffer));
+
+        result.m_ReturnCode = 1;
+        return result;
+    }
+    int length = strlen(payload);
+    int written = fwrite(payload, sizeof(char), length, f);
+    fclose(f);
+
+    if (written == length)
+        return result;
+
+    InitOutputBuffer(&result.m_OutputBuffer, heap);
+
+    snprintf(tmpBuffer, sizeof(tmpBuffer), "fwrite was supposed to write %d bytes to %s, but wrote %d bytes", length, target_file, written);
+    EmitOutputBytesToDestination(&result, tmpBuffer, strlen(tmpBuffer));
+
+    result.m_ReturnCode = 1;
+    return result;
+}

--- a/src/Actions.hpp
+++ b/src/Actions.hpp
@@ -17,7 +17,7 @@ namespace ActionType
         kUnknown = 0,
         kRunShellCommand = 1,
         kWriteTextFile = 2,
-    	kCopyFile = 3
+    	kCopyFiles = 3
     };
 
     Enum FromString(const char* name);
@@ -25,7 +25,8 @@ namespace ActionType
 }
 
 struct StatCache;
+struct FrozenFileAndHash;
 
 ExecResult WriteTextFile(const char* payload, const char* target_file, MemAllocHeap* heap);
-ExecResult CopyFile(const char* src_file, const char* target_file, StatCache* stat_cache, MemAllocHeap* heap);
+ExecResult CopyFiles(const FrozenFileAndHash* src_files, const FrozenFileAndHash* target_files, size_t files_count, StatCache* stat_cache, MemAllocHeap* heap);
 

--- a/src/Actions.hpp
+++ b/src/Actions.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdint.h>
+#include "Exec.hpp"
 
 namespace ActionType
 {
@@ -14,3 +15,6 @@ namespace ActionType
     Enum FromString(const char* name);
     const char* ToString(Enum value);
 }
+
+ExecResult WriteTextFile(const char* payload, const char* target_file, MemAllocHeap* heap);
+

--- a/src/Actions.hpp
+++ b/src/Actions.hpp
@@ -1,7 +1,14 @@
 #pragma once
 
-#include <stdint.h>
+#include "Config.hpp"
 #include "Exec.hpp"
+
+#include <stdint.h>
+
+// Windows.h defines CopyFile as a macro
+#if defined(TUNDRA_WIN32) && defined(CopyFile)
+#undef CopyFile
+#endif
 
 namespace ActionType
 {
@@ -16,5 +23,8 @@ namespace ActionType
     const char* ToString(Enum value);
 }
 
+struct StatCache;
+
 ExecResult WriteTextFile(const char* payload, const char* target_file, MemAllocHeap* heap);
+ExecResult CopyFile(const char* src_file, const char* target_file, StatCache* stat_cache, MemAllocHeap* heap);
 

--- a/src/Actions.hpp
+++ b/src/Actions.hpp
@@ -16,7 +16,8 @@ namespace ActionType
     {
         kUnknown = 0,
         kRunShellCommand = 1,
-        kWriteTextFile = 2
+        kWriteTextFile = 2,
+    	kCopyFile = 3
     };
 
     Enum FromString(const char* name);

--- a/src/ActionsApple.cpp
+++ b/src/ActionsApple.cpp
@@ -1,0 +1,116 @@
+#include "Actions.hpp"
+#include "MemAllocHeap.hpp"
+#include "StatCache.hpp"
+
+#if defined(TUNDRA_APPLE)
+
+#include <copyfile.h>
+#include <sys/time.h>
+#include <sys/stat.h>
+
+    ExecResult CopyFile(const char* src_file, const char* target_file, StatCache* stat_cache, MemAllocHeap* heap)
+    {
+        ExecResult result;
+        memset(&result, 0, sizeof(result));
+        char tmpBuffer[1024];
+
+        do
+        {
+            FileInfo src_file_info = StatCacheStat(stat_cache, src_file);
+            if (!src_file_info.Exists())
+            {
+                result.m_ReturnCode = -1;
+                snprintf(tmpBuffer, sizeof(tmpBuffer), "The source path %s does not exist.", src_file);
+                break;
+            }
+
+            if (src_file_info.IsDirectory())
+            {
+                result.m_ReturnCode = -1;
+                snprintf(tmpBuffer, sizeof(tmpBuffer), "The source path %s is a directory, which is not supported.", src_file);
+                break;
+            }
+
+            FileInfo dst_file_info = StatCacheStat(stat_cache, target_file);
+            if (dst_file_info.Exists())
+            {
+                if (dst_file_info.IsDirectory())
+                {
+                    result.m_ReturnCode = -1;
+                    snprintf(tmpBuffer, sizeof(tmpBuffer), "The target path %s already exists as a directory.", target_file);
+                    break;
+                }
+
+                if (dst_file_info.IsReadOnly())
+                {
+                    result.m_ReturnCode = -1;
+                    snprintf(tmpBuffer, sizeof(tmpBuffer), "The target path already exists and is read-only.");
+                    break;
+                }
+            }
+
+            copyfile_state_t state = copyfile_state_alloc();
+            result.m_ReturnCode = copyfile(src_file, target_file, state, COPYFILE_ALL | COPYFILE_UNLINK | COPYFILE_CLONE | COPYFILE_DATA_SPARSE);
+            copyfile_state_free(state);
+
+            // Mark the stat cache dirty regardless of whether we failed or not - the target file is in an unknown state now
+            StatCacheMarkDirty(stat_cache, target_file, Djb2HashPath(target_file));
+
+            if (result.m_ReturnCode < 0)
+            {
+                snprintf(tmpBuffer, sizeof(tmpBuffer), "Copying the file failed: %s", strerror(errno));
+                break;
+            }
+
+            // If we copied a symbolic link, we don't need to do any more work
+            if (src_file_info.IsSymlink())
+                break;
+
+            dst_file_info = StatCacheStat(stat_cache, target_file);
+
+            if (dst_file_info.m_Size != src_file_info.m_Size)
+            {
+                result.m_ReturnCode = -1;
+                snprintf(tmpBuffer, sizeof(tmpBuffer), "The copied file is %llu bytes, but the source file was %llu bytes.", dst_file_info.m_Size, src_file_info.m_Size);
+                break;
+            }
+
+            // Force the file to have the current timestamp
+            result.m_ReturnCode = utimes(target_file, NULL);
+            if (result.m_ReturnCode < 0)
+            {
+                snprintf(tmpBuffer, sizeof(tmpBuffer), "Updating the timestamp on the file failed: %s", strerror(errno));
+                break;
+            }
+
+            if (dst_file_info.IsReadOnly())
+            {
+                // We need to wipe the read-only bit on the target file
+                struct stat dst_stat;
+                result.m_ReturnCode = stat(target_file, &dst_stat);
+                if (result.m_ReturnCode < 0)
+                {
+                    snprintf(tmpBuffer, sizeof(tmpBuffer), "stat on the target file after the copy failed: %s", strerror(errno));
+                    break;
+                }
+
+                result.m_ReturnCode = chmod(target_file, (dst_stat.st_mode & 0x00007777) | S_IWUSR);
+                if (result.m_ReturnCode < 0)
+                {
+                    snprintf(tmpBuffer, sizeof(tmpBuffer), "Making the target file writable failed: %s", strerror(errno));
+                    break;
+                }
+            }
+
+        } while(0);
+
+        if (result.m_ReturnCode != 0)
+        {
+            InitOutputBuffer(&result.m_OutputBuffer, heap);
+            EmitOutputBytesToDestination(&result, tmpBuffer, strlen(tmpBuffer));
+        }
+
+        return result;
+    }
+
+#endif

--- a/src/ActionsApple.cpp
+++ b/src/ActionsApple.cpp
@@ -66,17 +66,20 @@ ExecResult CopyFiles(const FrozenFileAndHash* src_files, const FrozenFileAndHash
             break;
         }
 
-        // If we copied a symbolic link, we don't need to do any more work
-        if (src_file_info.IsSymlink())
-            continue;
-
         // Force the file to have the current timestamp
-        result.m_ReturnCode = utimes(target_file, NULL);
+        if (src_file_info.IsSymlink())
+            result.m_ReturnCode = lutimes(target_file, NULL);
+        else
+            result.m_ReturnCode = utimes(target_file, NULL);
         if (result.m_ReturnCode < 0)
         {
             snprintf(tmpBuffer, sizeof(tmpBuffer), "Updating the timestamp on the file %s failed: %s", target_file, strerror(errno));
             break;
         }
+
+        // Nothing else to do for symlinks
+        if (src_file_info.IsSymlink())
+            continue;
 
         if (src_file_info.IsReadOnly())
         {

--- a/src/ActionsApple.cpp
+++ b/src/ActionsApple.cpp
@@ -1,6 +1,7 @@
 #include "Actions.hpp"
 #include "MemAllocHeap.hpp"
 #include "StatCache.hpp"
+#include "BinaryData.hpp"
 
 #if defined(TUNDRA_APPLE)
 
@@ -8,109 +9,112 @@
 #include <sys/time.h>
 #include <sys/stat.h>
 
-    ExecResult CopyFile(const char* src_file, const char* target_file, StatCache* stat_cache, MemAllocHeap* heap)
+ExecResult CopyFiles(const FrozenFileAndHash* src_files, const FrozenFileAndHash* target_files, size_t files_count, StatCache* stat_cache, MemAllocHeap* heap)
+{
+    ExecResult result;
+    memset(&result, 0, sizeof(result));
+    char tmpBuffer[1024];
+
+    for(size_t i = 0; i < files_count; ++i)
     {
-        ExecResult result;
-        memset(&result, 0, sizeof(result));
-        char tmpBuffer[1024];
+        const char* src_file = src_files[i].m_Filename;
+        const char* target_file = target_files[i].m_Filename;
 
-        do
+        FileInfo src_file_info = StatCacheStat(stat_cache, src_file);
+        if (!src_file_info.Exists())
         {
-            FileInfo src_file_info = StatCacheStat(stat_cache, src_file);
-            if (!src_file_info.Exists())
+            result.m_ReturnCode = -1;
+            snprintf(tmpBuffer, sizeof(tmpBuffer), "The source path %s does not exist.", src_file);
+            break;
+        }
+
+        if (src_file_info.IsDirectory())
+        {
+            result.m_ReturnCode = -1;
+            snprintf(tmpBuffer, sizeof(tmpBuffer), "The source path %s is a directory, which is not supported.", src_file);
+            break;
+        }
+
+        FileInfo dst_file_info = StatCacheStat(stat_cache, target_file);
+        if (dst_file_info.Exists())
+        {
+            if (dst_file_info.IsDirectory())
             {
                 result.m_ReturnCode = -1;
-                snprintf(tmpBuffer, sizeof(tmpBuffer), "The source path %s does not exist.", src_file);
-                break;
-            }
-
-            if (src_file_info.IsDirectory())
-            {
-                result.m_ReturnCode = -1;
-                snprintf(tmpBuffer, sizeof(tmpBuffer), "The source path %s is a directory, which is not supported.", src_file);
-                break;
-            }
-
-            FileInfo dst_file_info = StatCacheStat(stat_cache, target_file);
-            if (dst_file_info.Exists())
-            {
-                if (dst_file_info.IsDirectory())
-                {
-                    result.m_ReturnCode = -1;
-                    snprintf(tmpBuffer, sizeof(tmpBuffer), "The target path %s already exists as a directory.", target_file);
-                    break;
-                }
-
-                if (dst_file_info.IsReadOnly())
-                {
-                    result.m_ReturnCode = -1;
-                    snprintf(tmpBuffer, sizeof(tmpBuffer), "The target path already exists and is read-only.");
-                    break;
-                }
-            }
-
-            copyfile_state_t state = copyfile_state_alloc();
-            result.m_ReturnCode = copyfile(src_file, target_file, state, COPYFILE_ALL | COPYFILE_UNLINK | COPYFILE_CLONE | COPYFILE_DATA_SPARSE);
-            copyfile_state_free(state);
-
-            // Mark the stat cache dirty regardless of whether we failed or not - the target file is in an unknown state now
-            StatCacheMarkDirty(stat_cache, target_file, Djb2HashPath(target_file));
-
-            if (result.m_ReturnCode < 0)
-            {
-                snprintf(tmpBuffer, sizeof(tmpBuffer), "Copying the file failed: %s", strerror(errno));
-                break;
-            }
-
-            // If we copied a symbolic link, we don't need to do any more work
-            if (src_file_info.IsSymlink())
-                break;
-
-            dst_file_info = StatCacheStat(stat_cache, target_file);
-
-            if (dst_file_info.m_Size != src_file_info.m_Size)
-            {
-                result.m_ReturnCode = -1;
-                snprintf(tmpBuffer, sizeof(tmpBuffer), "The copied file is %llu bytes, but the source file was %llu bytes.", dst_file_info.m_Size, src_file_info.m_Size);
-                break;
-            }
-
-            // Force the file to have the current timestamp
-            result.m_ReturnCode = utimes(target_file, NULL);
-            if (result.m_ReturnCode < 0)
-            {
-                snprintf(tmpBuffer, sizeof(tmpBuffer), "Updating the timestamp on the file failed: %s", strerror(errno));
+                snprintf(tmpBuffer, sizeof(tmpBuffer), "The target path %s already exists as a directory.", target_file);
                 break;
             }
 
             if (dst_file_info.IsReadOnly())
             {
-                // We need to wipe the read-only bit on the target file
-                struct stat dst_stat;
-                result.m_ReturnCode = stat(target_file, &dst_stat);
-                if (result.m_ReturnCode < 0)
-                {
-                    snprintf(tmpBuffer, sizeof(tmpBuffer), "stat on the target file after the copy failed: %s", strerror(errno));
-                    break;
-                }
-
-                result.m_ReturnCode = chmod(target_file, (dst_stat.st_mode & 0x00007777) | S_IWUSR);
-                if (result.m_ReturnCode < 0)
-                {
-                    snprintf(tmpBuffer, sizeof(tmpBuffer), "Making the target file writable failed: %s", strerror(errno));
-                    break;
-                }
+                result.m_ReturnCode = -1;
+                snprintf(tmpBuffer, sizeof(tmpBuffer), "The target path %s already exists and is read-only.", target_file);
+                break;
             }
-
-        } while(0);
-
-        if (result.m_ReturnCode != 0)
-        {
-            InitOutputBuffer(&result.m_OutputBuffer, heap);
-            EmitOutputBytesToDestination(&result, tmpBuffer, strlen(tmpBuffer));
         }
 
-        return result;
+        copyfile_state_t state = copyfile_state_alloc();
+        result.m_ReturnCode = copyfile(src_file, target_file, state, COPYFILE_ALL | COPYFILE_UNLINK | COPYFILE_CLONE | COPYFILE_DATA_SPARSE);
+        copyfile_state_free(state);
+
+        // Mark the stat cache dirty regardless of whether we failed or not - the target file is in an unknown state now
+        StatCacheMarkDirty(stat_cache, target_file, target_files[i].m_FilenameHash);
+
+        if (result.m_ReturnCode < 0)
+        {
+            snprintf(tmpBuffer, sizeof(tmpBuffer), "Copying the file %s failed: %s", target_file, strerror(errno));
+            break;
+        }
+
+        // If we copied a symbolic link, we don't need to do any more work
+        if (src_file_info.IsSymlink())
+            continue;
+
+        // Force the file to have the current timestamp
+        result.m_ReturnCode = utimes(target_file, NULL);
+        if (result.m_ReturnCode < 0)
+        {
+            snprintf(tmpBuffer, sizeof(tmpBuffer), "Updating the timestamp on the file %s failed: %s", target_file, strerror(errno));
+            break;
+        }
+
+        if (src_file_info.IsReadOnly())
+        {
+            // The source file was readonly, so we will need to wipe the read-only bit on the target file
+            struct stat dst_stat;
+            result.m_ReturnCode = stat(target_file, &dst_stat);
+            if (result.m_ReturnCode < 0)
+            {
+                snprintf(tmpBuffer, sizeof(tmpBuffer), "stat on the target file %s after the copy failed: %s", target_file, strerror(errno));
+                break;
+            }
+
+            result.m_ReturnCode = chmod(target_file, (dst_stat.st_mode & 0x00007777) | S_IWUSR);
+            if (result.m_ReturnCode < 0)
+            {
+                snprintf(tmpBuffer, sizeof(tmpBuffer), "Making the target file %s writable failed: %s", target_file, strerror(errno));
+                break;
+            }
+        }
+
+        // Verify that the copied file is the same size as the source.
+        // It's OK to use the statcache for this now because we've finished modifying the file
+        dst_file_info = StatCacheStat(stat_cache, target_file);
+        if (dst_file_info.m_Size != src_file_info.m_Size)
+        {
+            result.m_ReturnCode = -1;
+            snprintf(tmpBuffer, sizeof(tmpBuffer), "The copied file %s is %llu bytes, but the source file %s was %llu bytes.", target_file, dst_file_info.m_Size, src_file, src_file_info.m_Size);
+            break;
+        }
     }
+
+    if (result.m_ReturnCode != 0)
+    {
+        InitOutputBuffer(&result.m_OutputBuffer, heap);
+        EmitOutputBytesToDestination(&result, tmpBuffer, strlen(tmpBuffer));
+    }
+
+    return result;
+}
 
 #endif

--- a/src/ActionsLinux.cpp
+++ b/src/ActionsLinux.cpp
@@ -1,0 +1,205 @@
+#include <fcntl.h>
+
+#include "Actions.hpp"
+#include "MemAllocHeap.hpp"
+#include "StatCache.hpp"
+#include "BinaryData.hpp"
+#include "MemAllocLinear.hpp"
+
+#if defined(TUNDRA_LINUX)
+
+#include <sys/time.h>
+#include <sys/stat.h>
+#include <fnctl.h>
+
+ExecResult CopyFiles(const FrozenFileAndHash* src_files, const FrozenFileAndHash* target_files, size_t files_count, StatCache* stat_cache, MemAllocHeap* heap)
+{
+    ExecResult result;
+    memset(&result, 0, sizeof(result));
+    char tmpBuffer[1024];
+
+    int in_file = -1, out_file = -1;
+    int temporary_pipe[2] = { -1, -1 };
+    pipe(temporary_pipe);
+    const size_t splice_chunk_size = 4096;
+
+    MemAllocLinear scratch;
+    LinearAllocInit(&scratch, heap, 4096, "CopyFiles scratch memory");
+
+    for(size_t i = 0; i < files_count; ++i)
+    {
+        LinearAllocReset(&scratch);
+
+        const char* src_file = src_files[i].m_Filename;
+        const char* target_file = target_files[i].m_Filename;
+
+        // The StatCache is not used for the file info because we need full stat info (file modes, etc) which FileInfo doesn't give us
+        struct stat src_stat;
+        if (lstat(src_file, &src_stat) != 0)
+        {
+            result.m_ReturnCode = -1;
+            snprintf(tmpBuffer, sizeof(tmpBuffer), "The properties of source file %s could not be retrieved: %s", src_file, strerror(errno));
+            break;
+        }
+
+        if (S_ISDIR(src_stat.st_mode))
+        {
+            result.m_ReturnCode = -1;
+            snprintf(tmpBuffer, sizeof(tmpBuffer), "The source path %s is a directory, which is not supported.", src_file);
+            break;
+        }
+
+        FileInfo dst_file_info = StatCacheStat(stat_cache, target_file);
+        if (dst_file_info.Exists())
+        {
+            if (dst_file_info.IsDirectory())
+            {
+                result.m_ReturnCode = -1;
+                snprintf(tmpBuffer, sizeof(tmpBuffer), "The target path %s already exists as a directory.", target_file);
+                break;
+            }
+
+            if (dst_file_info.IsReadOnly())
+            {
+                result.m_ReturnCode = -1;
+                snprintf(tmpBuffer, sizeof(tmpBuffer), "The target path %s already exists and is read-only.", target_file);
+                break;
+            }
+        }
+
+        if ((src_stat.st_mode & S_IFMT) == S_IFLNK)
+        {
+            // It's a symlink
+
+            // Add 2 bytes, 1 for the null character and one so we can tell that the readlink return value did not get truncated
+            size_t bufferSize = src_stat.st_size + 2; 
+            char* link_contents = static_cast<char*>(LinearAllocate(&scratch, bufferSize, 1));
+            int link_size = readlink(src_file, link_contents, bufferSize);
+            if (link_size == bufferSize)
+            {
+                result.m_ReturnCode = -1;
+                snprintf(tmpBuffer, sizeof(tmpBuffer), "The source symlink %s could not be read with a consistent size.", src_file);
+                break;
+            }
+
+            if (dst_file_info.Exists())
+            {
+                _unlink(target_file);
+            }
+
+            if (symlink(link_contents, target_file) != 0)
+            {
+                result.m_ReturnCode = -1;
+                snprintf(tmpBuffer, sizeof(tmpBuffer), "The target symlink %s could not be created.", target_file);
+                break;
+            }
+
+            // Mark the stat cache dirty
+            StatCacheMarkDirty(stat_cache, target_file, target_files[i].m_FilenameHash);
+        }
+        else
+        {
+            // It's a regular file
+            in_file = open(src_file, O_RDONLY);
+            if (in_file == -1)
+            {
+                result.m_ReturnCode = -1;
+                snprintf(tmpBuffer, sizeof(tmpBuffer), "The source file %s could not be opened for reading: %s", src_file, strerror(errno));
+                break;
+            }
+
+            // Ensure that the target file is opened with a writable mode, even if the input file was readonly
+            out_file = open(target_file, O_WRONLY | O_CREAT | O_TRUNC, src_stat.st_mode | S_IWUSR);
+            if (out_file == -1)
+            {
+                result.m_ReturnCode = -1;
+                snprintf(tmpBuffer, sizeof(tmpBuffer), "The destination file %s could not be opened for writing: %s", src_file, strerror(errno));
+                break;
+            }
+
+            // See if it is on the same filesystem (which it usually will be) - if it is, we can try using the FICLONE ioctl to do a lightweight copy-on-write copy
+            struct stat dst_stat;
+            if (fstat(out_file, &dst_stat) != 0)
+            {
+                result.m_ReturnCode = -1;
+                snprintf(tmpBuffer, sizeof(tmpBuffer), "The properties of the destination file %s could not be retrieved: %s", target_file, strerror(errno));
+                break;
+            }
+
+            do {
+                if (src_stat.st_dev == dst_stat.st_dev)
+                {
+                    // Try the IOCTL. We don't particularly care about errors here, we'll just fall back if this fails
+                    if (ioctl(out_file, FICLONE, in_file) != -1)
+                    {
+                        // It worked!
+                        break;
+                    }
+                }
+
+                // Otherwise, next fastest method is to ask the kernel to do the copy using splice
+                size_t bytes_in, bytes_out;
+                do
+                {
+                    bytes_in = splice(in_file, NULL, temporary_pipe[0], NULL, src_stat.st_blksize, 0);
+                    if (bytes_in == -1)
+                    {
+                        result.m_ReturnCode = -1;
+                        snprintf(tmpBuffer, sizeof(tmpBuffer), "Reading from the source file %s failed: %s", src_file, strerror(errno));
+                        break;
+                    }
+
+                    bytes_out = splice(temporary_pipe[1], NULL, out_file, NULL, bytes_in, 0);
+                    if (bytes_out == -1)
+                    {
+                        result.m_ReturnCode = -1;
+                        snprintf(tmpBuffer, sizeof(tmpBuffer), "Writing to the destination file %s failed: %s", target_file, strerror(errno));
+                        break;
+                    }
+                } while (bytes_out > 0);
+
+            } while (false);
+
+            close(in_file);
+            in_file = -1;
+
+            close(out_file);
+            out_file = -1;
+
+            // Mark the stat cache dirty regardless of whether we failed or not - the target file is in an unknown state now
+            StatCacheMarkDirty(stat_cache, target_file, target_files[i].m_FilenameHash);
+
+            // Verify that the copied file is the same size as the source.
+            // It's OK to use the statcache for this now because we've finished modifying the file
+            dst_file_info = StatCacheStat(stat_cache, target_file);
+            if (dst_file_info.m_Size != src_stat.st_size)
+            {
+                result.m_ReturnCode = -1;
+                snprintf(tmpBuffer, sizeof(tmpBuffer), "The copied file %s is %llu bytes, but the source file %s was %llu bytes.", target_file, dst_file_info.m_Size, src_file, src_file_info.m_Size);
+                break;
+            }
+        }
+
+        if (result.m_ReturnCode < 0)
+            break;
+    }
+
+    close(temporary_pipe[0]);
+    close(temporary_pipe[1]);
+    if (in_file != -1)
+        close(in_file);
+    if (out_file != -1)
+        close(out_file);
+
+    if (result.m_ReturnCode != 0)
+    {
+        InitOutputBuffer(&result.m_OutputBuffer, heap);
+        EmitOutputBytesToDestination(&result, tmpBuffer, strlen(tmpBuffer));
+    }
+
+    LinearAllocDestroy(&scratch);
+
+    return result;
+}
+
+#endif

--- a/src/ActionsLinux.cpp
+++ b/src/ActionsLinux.cpp
@@ -146,7 +146,7 @@ ExecResult CopyFiles(const FrozenFileAndHash* src_files, const FrozenFileAndHash
                 size_t bytes_in, bytes_out;
                 do
                 {
-                    bytes_in = splice(in_file, NULL, temporary_pipe[0], NULL, src_stat.st_blksize, 0);
+                    bytes_in = splice(in_file, NULL, temporary_pipe[1], NULL, src_stat.st_blksize, 0);
                     if (bytes_in == -1)
                     {
                         result.m_ReturnCode = -1;
@@ -154,7 +154,7 @@ ExecResult CopyFiles(const FrozenFileAndHash* src_files, const FrozenFileAndHash
                         break;
                     }
 
-                    bytes_out = splice(temporary_pipe[1], NULL, out_file, NULL, bytes_in, 0);
+                    bytes_out = splice(temporary_pipe[0], NULL, out_file, NULL, bytes_in, 0);
                     if (bytes_out == -1)
                     {
                         result.m_ReturnCode = -1;

--- a/src/ActionsLinux.cpp
+++ b/src/ActionsLinux.cpp
@@ -11,6 +11,7 @@
 #include <sys/time.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <unistd.h>
 #include <linux/fs.h>
 #ifdef FICLONE
 #include <sys/ioctl.h>

--- a/src/ActionsLinux.cpp
+++ b/src/ActionsLinux.cpp
@@ -88,9 +88,7 @@ ExecResult CopyFiles(const FrozenFileAndHash* src_files, const FrozenFileAndHash
             }
 
             if (dst_file_info.Exists())
-            {
-                _unlink(target_file);
-            }
+                unlink(target_file);
 
             if (symlink(link_contents, target_file) != 0)
             {
@@ -182,7 +180,7 @@ ExecResult CopyFiles(const FrozenFileAndHash* src_files, const FrozenFileAndHash
             if (dst_file_info.m_Size != src_stat.st_size)
             {
                 result.m_ReturnCode = -1;
-                snprintf(tmpBuffer, sizeof(tmpBuffer), "The copied file %s is %llu bytes, but the source file %s was %llu bytes.", target_file, dst_file_info.m_Size, src_file, src_file_info.m_Size);
+                snprintf(tmpBuffer, sizeof(tmpBuffer), "The copied file %s is %llu bytes, but the source file %s was %llu bytes.", target_file, dst_file_info.m_Size, src_file, src_stat.st_size);
                 break;
             }
         }

--- a/src/ActionsWin32.cpp
+++ b/src/ActionsWin32.cpp
@@ -1,0 +1,134 @@
+
+#include "Actions.hpp"
+#include "StatCache.hpp"
+
+#if defined(TUNDRA_WIN32)
+
+#include <fileapi.h>
+#if defined (CopyFile)
+#undef CopyFile
+#endif
+
+ExecResult CopyFile(const char* src_file, const char* target_file, StatCache* stat_cache, MemAllocHeap* heap)
+{
+  ExecResult result;
+  memset(&result, 0, sizeof(result));
+  char tmpBuffer[1024];
+
+  do
+  {
+    FileInfo src_file_info = StatCacheStat(stat_cache, src_file);
+    if (!src_file_info.Exists())
+    {
+      result.m_ReturnCode = -1;
+      snprintf(tmpBuffer, sizeof(tmpBuffer), "The source path %s does not exist.", src_file);
+      break;
+    }
+
+    if (src_file_info.IsDirectory())
+    {
+      result.m_ReturnCode = -1;
+      snprintf(tmpBuffer, sizeof(tmpBuffer), "The source path %s is a directory, which is not supported.", src_file);
+      break;
+    }
+
+    FileInfo dst_file_info = StatCacheStat(stat_cache, target_file);
+    if (dst_file_info.Exists())
+    {
+      if (dst_file_info.IsDirectory())
+      {
+        result.m_ReturnCode = -1;
+        snprintf(tmpBuffer, sizeof(tmpBuffer), "The target path %s already exists as a directory.", target_file);
+        break;
+      }
+
+      if (dst_file_info.IsReadOnly())
+      {
+        result.m_ReturnCode = -1;
+        snprintf(tmpBuffer, sizeof(tmpBuffer), "The target path already exists and is read-only.");
+        break;
+      }
+    }
+
+    BOOL cancel = false;
+    if (CopyFileEx(src_file, target_file, NULL, NULL, &cancel, COPY_FILE_COPY_SYMLINK) == 0)
+      result.m_ReturnCode = GetLastError();
+
+    // Mark the stat cache dirty regardless of whether we failed or not - the target file is in an unknown state now
+    StatCacheMarkDirty(stat_cache, target_file, Djb2HashPath(target_file));
+
+    if (result.m_ReturnCode != 0)
+    {
+      LPSTR messageBuffer = nullptr;
+      FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+        NULL, result.m_ReturnCode, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)& messageBuffer, 0, NULL);
+      snprintf(tmpBuffer, sizeof(tmpBuffer), "Copying the file failed: %s", messageBuffer);
+      LocalFree(messageBuffer);
+      break;
+    }
+
+    // If we copied a symbolic link, we don't need to do any more work
+    if (src_file_info.IsSymlink())
+      break;
+
+    dst_file_info = StatCacheStat(stat_cache, target_file);
+
+    if (dst_file_info.m_Size != src_file_info.m_Size)
+    {
+      result.m_ReturnCode = -1;
+      snprintf(tmpBuffer, sizeof(tmpBuffer), "The copied file is %llu bytes, but the source file was %llu bytes.", dst_file_info.m_Size, src_file_info.m_Size);
+      break;
+    }
+
+    // Force the file to have the current timestamp
+    HANDLE hFile = CreateFileA(target_file, FILE_WRITE_ATTRIBUTES, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+    if (hFile == INVALID_HANDLE_VALUE)
+    {
+      result.m_ReturnCode = GetLastError();
+    }
+    else
+    {
+      FILETIME now;
+      GetSystemTimeAsFileTime(&now);
+      if (!SetFileTime(hFile, NULL, NULL, &now))
+        result.m_ReturnCode = GetLastError();
+      CloseHandle(hFile);
+    }
+
+    if (result.m_ReturnCode < 0)
+    {
+      LPSTR messageBuffer = nullptr;
+      FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+        NULL, result.m_ReturnCode, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)& messageBuffer, 0, NULL);
+      snprintf(tmpBuffer, sizeof(tmpBuffer), "Updating the timestamp on the file failed: %s", messageBuffer);
+      LocalFree(messageBuffer);
+      break;
+    }
+
+    if (dst_file_info.IsReadOnly())
+    {
+      DWORD currentAttributes = GetFileAttributes(target_file);
+      if (!SetFileAttributes(target_file, currentAttributes & ~FILE_ATTRIBUTE_READONLY))
+      {
+        result.m_ReturnCode = GetLastError();
+        LPSTR messageBuffer = nullptr;
+        FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+          NULL, result.m_ReturnCode, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)& messageBuffer, 0, NULL);
+        snprintf(tmpBuffer, sizeof(tmpBuffer), "Clearing the readonly flag on the file failed: %s", messageBuffer);
+        LocalFree(messageBuffer);
+        break;
+      }
+    }
+
+  } while (false);
+
+  if (result.m_ReturnCode != 0)
+  {
+    InitOutputBuffer(&result.m_OutputBuffer, heap);
+    EmitOutputBytesToDestination(&result, tmpBuffer, strlen(tmpBuffer));
+  }
+
+  return result;
+}
+
+#endif

--- a/src/ActionsWin32.cpp
+++ b/src/ActionsWin32.cpp
@@ -98,7 +98,7 @@ ExecResult CopyFile(const char* src_file, const char* target_file, StatCache* st
       CloseHandle(hFile);
     }
 
-    if (result.m_ReturnCode < 0)
+    if (result.m_ReturnCode != 0)
     {
       LPWSTR messageBuffer = nullptr;
       FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,

--- a/src/ActionsWin32.cpp
+++ b/src/ActionsWin32.cpp
@@ -103,7 +103,7 @@ ExecResult CopyFiles(const FrozenFileAndHash* src_files, const FrozenFileAndHash
             break;
         }
 
-        if (dst_file_info.IsReadOnly())
+        if (src_file_info.IsReadOnly())
         {
             DWORD currentAttributes = GetFileAttributesW(target_file_wide.c_str());
             if (!SetFileAttributesW(target_file_wide.c_str(), currentAttributes & ~FILE_ATTRIBUTE_READONLY))

--- a/src/ActionsWin32.cpp
+++ b/src/ActionsWin32.cpp
@@ -1,6 +1,7 @@
 
 #include "Actions.hpp"
 #include "StatCache.hpp"
+#include "BinaryData.hpp"
 
 #if defined(TUNDRA_WIN32)
 
@@ -9,129 +10,133 @@
 #undef CopyFile
 #endif
 
-ExecResult CopyFile(const char* src_file, const char* target_file, StatCache* stat_cache, MemAllocHeap* heap)
+ExecResult CopyFiles(const FrozenFileAndHash* src_files, const FrozenFileAndHash* target_files, size_t files_count, StatCache* stat_cache, MemAllocHeap* heap)
 {
-  ExecResult result;
-  memset(&result, 0, sizeof(result));
-  char tmpBuffer[1024];
+    ExecResult result;
+    memset(&result, 0, sizeof(result));
+    char tmpBuffer[1024];
 
-  do
-  {
-    FileInfo src_file_info = StatCacheStat(stat_cache, src_file);
-    if (!src_file_info.Exists())
+    for(size_t i = 0; i < files_count; ++i)
     {
-      result.m_ReturnCode = -1;
-      snprintf(tmpBuffer, sizeof(tmpBuffer), "The source path %s does not exist.", src_file);
-      break;
+        const char* src_file = src_files[i].m_Filename;
+        const char* target_file = target_files[i].m_Filename;
+
+        FileInfo src_file_info = StatCacheStat(stat_cache, src_file);
+        if (!src_file_info.Exists())
+        {
+            result.m_ReturnCode = -1;
+            snprintf(tmpBuffer, sizeof(tmpBuffer), "The source path %s does not exist.", src_file);
+            break;
+        }
+
+        if (src_file_info.IsDirectory())
+        {
+            result.m_ReturnCode = -1;
+            snprintf(tmpBuffer, sizeof(tmpBuffer), "The source path %s is a directory, which is not supported.", src_file);
+            break;
+        }
+
+        FileInfo dst_file_info = StatCacheStat(stat_cache, target_file);
+        if (dst_file_info.Exists())
+        {
+            if (dst_file_info.IsDirectory())
+            {
+                result.m_ReturnCode = -1;
+                snprintf(tmpBuffer, sizeof(tmpBuffer), "The target path %s already exists as a directory.", target_file);
+                break;
+            }
+
+            if (dst_file_info.IsReadOnly())
+            {
+                result.m_ReturnCode = -1;
+                snprintf(tmpBuffer, sizeof(tmpBuffer), "The target path already exists and is read-only.");
+                break;
+            }
+        }
+
+        std::wstring src_file_wide = ToWideString(src_file);
+        std::wstring target_file_wide = ToWideString(target_file);
+
+        BOOL cancel = false;
+        if (CopyFileExW(src_file_wide.c_str(), target_file_wide.c_str(), NULL, NULL, &cancel, COPY_FILE_COPY_SYMLINK) == 0)
+            result.m_ReturnCode = GetLastError();
+
+        // Mark the stat cache dirty regardless of whether we failed or not - the target file is in an unknown state now
+        StatCacheMarkDirty(stat_cache, target_file, target_files[i].m_FilenameHash);
+
+        if (result.m_ReturnCode != 0)
+        {
+            LPWSTR messageBuffer = nullptr;
+            FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                NULL, result.m_ReturnCode, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)& messageBuffer, 0, NULL);
+            snprintf(tmpBuffer, sizeof(tmpBuffer), "Copying the file failed: %s", ToMultiByteUTF8String(messageBuffer).c_str());
+            LocalFree(messageBuffer);
+            break;
+        }
+
+        // If we copied a symbolic link, we don't need to do any more work
+        if (src_file_info.IsSymlink())
+            continue;
+
+        // Force the file to have the current timestamp
+        HANDLE hFile = CreateFileW(target_file_wide.c_str(), FILE_WRITE_ATTRIBUTES, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+        if (hFile == INVALID_HANDLE_VALUE)
+        {
+            result.m_ReturnCode = GetLastError();
+        }
+        else
+        {
+            FILETIME now;
+            GetSystemTimeAsFileTime(&now);
+            if (!SetFileTime(hFile, NULL, NULL, &now))
+                result.m_ReturnCode = GetLastError();
+            CloseHandle(hFile);
+        }
+
+        if (result.m_ReturnCode != 0)
+        {
+            LPWSTR messageBuffer = nullptr;
+            FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                NULL, result.m_ReturnCode, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)& messageBuffer, 0, NULL);
+            snprintf(tmpBuffer, sizeof(tmpBuffer), "Updating the timestamp on the file failed: %s", ToMultiByteUTF8String(messageBuffer).c_str());
+            LocalFree(messageBuffer);
+            break;
+        }
+
+        if (dst_file_info.IsReadOnly())
+        {
+            DWORD currentAttributes = GetFileAttributesW(target_file_wide.c_str());
+            if (!SetFileAttributesW(target_file_wide.c_str(), currentAttributes & ~FILE_ATTRIBUTE_READONLY))
+            {
+                result.m_ReturnCode = GetLastError();
+                LPWSTR messageBuffer = nullptr;
+                FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                NULL, result.m_ReturnCode, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)& messageBuffer, 0, NULL);
+                snprintf(tmpBuffer, sizeof(tmpBuffer), "Clearing the readonly flag on the file failed: %s", ToMultiByteUTF8String(messageBuffer).c_str());
+                LocalFree(messageBuffer);
+                break;
+            }
+        }
+
+        // Verify that the size of the copied file is correct
+        // It's OK to use the stat cache for this as we've finished modifying the file
+        dst_file_info = StatCacheStat(stat_cache, target_file);
+
+        if (dst_file_info.m_Size != src_file_info.m_Size)
+        {
+            result.m_ReturnCode = -1;
+            snprintf(tmpBuffer, sizeof(tmpBuffer), "The copied file is %llu bytes, but the source file was %llu bytes.", dst_file_info.m_Size, src_file_info.m_Size);
+            break;
+        }
     }
-
-    if (src_file_info.IsDirectory())
-    {
-      result.m_ReturnCode = -1;
-      snprintf(tmpBuffer, sizeof(tmpBuffer), "The source path %s is a directory, which is not supported.", src_file);
-      break;
-    }
-
-    FileInfo dst_file_info = StatCacheStat(stat_cache, target_file);
-    if (dst_file_info.Exists())
-    {
-      if (dst_file_info.IsDirectory())
-      {
-        result.m_ReturnCode = -1;
-        snprintf(tmpBuffer, sizeof(tmpBuffer), "The target path %s already exists as a directory.", target_file);
-        break;
-      }
-
-      if (dst_file_info.IsReadOnly())
-      {
-        result.m_ReturnCode = -1;
-        snprintf(tmpBuffer, sizeof(tmpBuffer), "The target path already exists and is read-only.");
-        break;
-      }
-    }
-
-    std::wstring src_file_wide = ToWideString(src_file);
-    std::wstring target_file_wide = ToWideString(target_file);
-
-    BOOL cancel = false;
-    if (CopyFileExW(src_file_wide.c_str(), target_file_wide.c_str(), NULL, NULL, &cancel, COPY_FILE_COPY_SYMLINK) == 0)
-      result.m_ReturnCode = GetLastError();
-
-    // Mark the stat cache dirty regardless of whether we failed or not - the target file is in an unknown state now
-    StatCacheMarkDirty(stat_cache, target_file, Djb2HashPath(target_file));
 
     if (result.m_ReturnCode != 0)
     {
-      LPWSTR messageBuffer = nullptr;
-      FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-        NULL, result.m_ReturnCode, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)& messageBuffer, 0, NULL);
-      snprintf(tmpBuffer, sizeof(tmpBuffer), "Copying the file failed: %s", ToMultiByteUTF8String(messageBuffer).c_str());
-      LocalFree(messageBuffer);
-      break;
+        InitOutputBuffer(&result.m_OutputBuffer, heap);
+        EmitOutputBytesToDestination(&result, tmpBuffer, strlen(tmpBuffer));
     }
 
-    // If we copied a symbolic link, we don't need to do any more work
-    if (src_file_info.IsSymlink())
-      break;
-
-    dst_file_info = StatCacheStat(stat_cache, target_file);
-
-    if (dst_file_info.m_Size != src_file_info.m_Size)
-    {
-      result.m_ReturnCode = -1;
-      snprintf(tmpBuffer, sizeof(tmpBuffer), "The copied file is %llu bytes, but the source file was %llu bytes.", dst_file_info.m_Size, src_file_info.m_Size);
-      break;
-    }
-
-    // Force the file to have the current timestamp
-    HANDLE hFile = CreateFileW(target_file_wide.c_str(), FILE_WRITE_ATTRIBUTES, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
-    if (hFile == INVALID_HANDLE_VALUE)
-    {
-      result.m_ReturnCode = GetLastError();
-    }
-    else
-    {
-      FILETIME now;
-      GetSystemTimeAsFileTime(&now);
-      if (!SetFileTime(hFile, NULL, NULL, &now))
-        result.m_ReturnCode = GetLastError();
-      CloseHandle(hFile);
-    }
-
-    if (result.m_ReturnCode != 0)
-    {
-      LPWSTR messageBuffer = nullptr;
-      FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-        NULL, result.m_ReturnCode, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)& messageBuffer, 0, NULL);
-      snprintf(tmpBuffer, sizeof(tmpBuffer), "Updating the timestamp on the file failed: %s", ToMultiByteUTF8String(messageBuffer).c_str());
-      LocalFree(messageBuffer);
-      break;
-    }
-
-    if (dst_file_info.IsReadOnly())
-    {
-      DWORD currentAttributes = GetFileAttributesW(target_file_wide.c_str());
-      if (!SetFileAttributesW(target_file_wide.c_str(), currentAttributes & ~FILE_ATTRIBUTE_READONLY))
-      {
-        result.m_ReturnCode = GetLastError();
-        LPWSTR messageBuffer = nullptr;
-        FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-          NULL, result.m_ReturnCode, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)& messageBuffer, 0, NULL);
-        snprintf(tmpBuffer, sizeof(tmpBuffer), "Clearing the readonly flag on the file failed: %s", ToMultiByteUTF8String(messageBuffer).c_str());
-        LocalFree(messageBuffer);
-        break;
-      }
-    }
-
-  } while (false);
-
-  if (result.m_ReturnCode != 0)
-  {
-    InitOutputBuffer(&result.m_OutputBuffer, heap);
-    EmitOutputBytesToDestination(&result, tmpBuffer, strlen(tmpBuffer));
-  }
-
-  return result;
+    return result;
 }
 
 #endif

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -403,6 +403,14 @@ std::wstring ToWideString(const char* input)
     return result;
 }
 
+std::string ToMultiByteUTF8String(const wchar_t* input)
+{
+    int size = WideCharToMultiByte(CP_UTF8, 0, input, wcslen(input), 0, 0, NULL, NULL);
+    std::string result(size, L'\0');
+    if (size) WideCharToMultiByte(CP_UTF8, 0, input, wcslen(input), &result[0], size, NULL, NULL);
+    return result;
+}
+
 bool ConvertToLongPath(std::wstring* path)
 {
     if (path == nullptr) return false;

--- a/src/Common.hpp
+++ b/src/Common.hpp
@@ -44,6 +44,7 @@
 
 #if TUNDRA_WIN32
 std::wstring ToWideString(const char* input);
+std::string ToMultiByteUTF8String(const wchar_t* input);
 bool ConvertToLongPath(std::wstring* path);
 #endif
 

--- a/src/DagGenerator.cpp
+++ b/src/DagGenerator.cpp
@@ -317,10 +317,10 @@ static bool WriteNodes(
             case ActionType::kRunShellCommand:
                 WriteStringPtr(node_data_seg, str_seg, action);
                 break;
-            case ActionType::kWriteTextFile:            
+            case ActionType::kWriteTextFile:
                 WriteStringPtr(node_data_seg, writetextfile_payloads_seg, writetextfile_payload);
                 break;
-            case ActionType::kCopyFile:
+            case ActionType::kCopyFiles:
                 BinarySegmentWriteNullPointer(node_data_seg);
                 break;
             case ActionType::kUnknown:
@@ -359,7 +359,7 @@ static bool WriteNodes(
         writeDependencyIndexList(toBuildDependencies);
         writeDependencyIndexList(toUseDependencies);
 
-        if (actionType == ActionType::kCopyFile && (inputs->m_Count != 1 || outputs->m_Count != 1))
+        if (actionType == ActionType::kCopyFiles && (inputs->m_Count != outputs->m_Count))
         {
             return false;
         }

--- a/src/DagGenerator.cpp
+++ b/src/DagGenerator.cpp
@@ -320,6 +320,9 @@ static bool WriteNodes(
             case ActionType::kWriteTextFile:            
                 WriteStringPtr(node_data_seg, writetextfile_payloads_seg, writetextfile_payload);
                 break;
+            case ActionType::kCopyFile:
+                BinarySegmentWriteNullPointer(node_data_seg);
+                break;
             case ActionType::kUnknown:
                 return false;
         }
@@ -355,6 +358,11 @@ static bool WriteNodes(
 
         writeDependencyIndexList(toBuildDependencies);
         writeDependencyIndexList(toUseDependencies);
+
+        if (actionType == ActionType::kCopyFile && (inputs->m_Count != 1 || outputs->m_Count != 1))
+        {
+            return false;
+        }
 
         WriteFileArray(node_data_seg, array2_seg, str_seg, inputs);
         WriteFileArray(node_data_seg, array2_seg, str_seg, filesThatMightBeIncluded);

--- a/src/Hash.hpp
+++ b/src/Hash.hpp
@@ -168,7 +168,7 @@ void HashUpdate(HashState *h, const void *data, size_t size);
 // Add string data to be hashed.
 inline void HashAddString(HashState *self, const char *s)
 {
-    HashUpdate(self, s, strlen(s));
+    HashUpdate(self, s, s ? strlen(s) : 0);
 }
 
 inline void HashAddString(FILE* debug_hash_fd, HashState* state, const char* label, const char* str)

--- a/src/InputSignature.cpp
+++ b/src/InputSignature.cpp
@@ -127,7 +127,9 @@ static void ReportInputSignatureChanges(
     int sha_extension_hash_count,
     ThreadState *thread_state)
 {
-    if (strcmp(dagnode->m_Action, previously_built_node->m_Action) != 0)
+    if ((dagnode->m_Action == nullptr && previously_built_node->m_Action != nullptr)
+      ||(dagnode->m_Action != nullptr && previously_built_node->m_Action == nullptr)
+      ||(dagnode->m_Action != nullptr && previously_built_node->m_Action != nullptr && strcmp(dagnode->m_Action, previously_built_node->m_Action) != 0))
     {
         JsonWriteStartObject(msg);
 

--- a/src/RunAction.cpp
+++ b/src/RunAction.cpp
@@ -88,6 +88,11 @@ static ExecResult RunActualAction(RuntimeNode* node, ThreadState* thread_state, 
             *out_validationresult = ValidationResult::Pass;
             return WriteTextFile(node_data->m_WriteTextPayload, node_data->m_OutputFiles[0].m_Filename, thread_state->m_Queue->m_Config.m_Heap);
         }
+        case ActionType::kCopyFile:
+        {
+            *out_validationresult = ValidationResult::Pass;
+            return CopyFile(node_data->m_InputFiles[0].m_Filename, node_data->m_OutputFiles[0].m_Filename, thread_state->m_Queue->m_Config.m_StatCache, thread_state->m_Queue->m_Config.m_Heap);
+        }
         case ActionType::kUnknown:
         default:
         {

--- a/src/RunAction.cpp
+++ b/src/RunAction.cpp
@@ -88,10 +88,10 @@ static ExecResult RunActualAction(RuntimeNode* node, ThreadState* thread_state, 
             *out_validationresult = ValidationResult::Pass;
             return WriteTextFile(node_data->m_WriteTextPayload, node_data->m_OutputFiles[0].m_Filename, thread_state->m_Queue->m_Config.m_Heap);
         }
-        case ActionType::kCopyFile:
+        case ActionType::kCopyFiles:
         {
             *out_validationresult = ValidationResult::Pass;
-            return CopyFile(node_data->m_InputFiles[0].m_Filename, node_data->m_OutputFiles[0].m_Filename, thread_state->m_Queue->m_Config.m_StatCache, thread_state->m_Queue->m_Config.m_Heap);
+            return CopyFiles(node_data->m_InputFiles.GetArray(), node_data->m_OutputFiles.GetArray(), node_data->m_InputFiles.GetCount(), thread_state->m_Queue->m_Config.m_StatCache, thread_state->m_Queue->m_Config.m_Heap);
         }
         case ActionType::kUnknown:
         default:

--- a/src/RunAction.cpp
+++ b/src/RunAction.cpp
@@ -45,40 +45,6 @@ static int SlowCallback(void *user_data)
     return sendNextCallbackIn;
 }
 
-static ExecResult WriteTextFile(const char *payload, const char *target_file, MemAllocHeap *heap)
-{
-    ExecResult result;
-    char tmpBuffer[1024];
-
-    memset(&result, 0, sizeof(result));
-
-    FILE *f = fopen(target_file, "wb");
-    if (!f)
-    {
-        InitOutputBuffer(&result.m_OutputBuffer, heap);
-
-        snprintf(tmpBuffer, sizeof(tmpBuffer), "Error opening for writing the file: %s, error: %s", target_file, strerror(errno));
-        EmitOutputBytesToDestination(&result, tmpBuffer, strlen(tmpBuffer));
-
-        result.m_ReturnCode = 1;
-        return result;
-    }
-    int length = strlen(payload);
-    int written = fwrite(payload, sizeof(char), length, f);
-    fclose(f);
-
-    if (written == length)
-        return result;
-
-    InitOutputBuffer(&result.m_OutputBuffer, heap);
-
-    snprintf(tmpBuffer, sizeof(tmpBuffer), "fwrite was supposed to write %d bytes to %s, but wrote %d bytes", length, target_file, written);
-    EmitOutputBytesToDestination(&result, tmpBuffer, strlen(tmpBuffer));
-
-    result.m_ReturnCode = 1;
-    return result;
-}
-
 static bool IsRunShellCommandAction(RuntimeNode* node)
 {
     return (node->m_DagNode->m_FlagsAndActionType & Frozen::DagNode::kFlagActionTypeMask) == ActionType::kRunShellCommand;


### PR DESCRIPTION
Allow an action to be specified as a 'copy file' node, which will cause Tundra to copy the input file to the output path, using direct file copy API calls, instead of the current approach of spawning a shell to run a copy command.

On my PC, I measured the performance by building the Editor, deleting the `build/WinEditor` folder, and then building again (which is _mostly_ CopyFile actions). The subsequent build:
* With shell command copies: total execution time 213 seconds, average CPU utilization 38.68%
* With built-in copy action: total execution time 99 seconds, average CPU utilization 28.92%

This will not correspond directly to a 114 second improvement in build times because these copies are often happening in parallel with other actions, but I think this is still a pretty good improvement.

Other side effects of this new mechanism:
* Hidden files can now be copied on Windows. Previously they would fail with 'file not found' errors.
* Error messages are now much improved, because we write them ourselves.

Corresponding Unity PR with the tests: https://github.cds.internal.unity3d.com/unity/unity/pull/2531