### PR TITLE
Report which glob/file is causing a frontend rerun

### DIFF
--- a/src/BuildQueue.hpp
+++ b/src/BuildQueue.hpp
@@ -53,7 +53,6 @@ struct BuildQueueConfig
     int m_SharedResourcesCount;
     bool m_AttemptCacheReads;
     bool m_AttemptCacheWrites;
-
 };
 
 struct BuildQueue;
@@ -65,6 +64,11 @@ struct ThreadState
     int m_ThreadIndex;
     int m_ProfilerThreadId;
     BuildQueue *m_Queue;
+
+    // For tracking which invalidated glob/file signature is causing a frontend rerun to be required
+    // Only storing one of each type is sufficient for figuring out what message to give the user
+    const Frozen::DagGlobSignature *m_GlobCausingFrontendRerun;
+    const Frozen::DagFileSignature *m_FileCausingFrontendRerun;
 };
 
 namespace BuildResult
@@ -112,3 +116,5 @@ BuildResult::Enum BuildQueueBuild(BuildQueue *queue, MemAllocLinear* scratch);
 void BuildQueueDestroy(BuildQueue *queue);
 
 bool HasBuildStoppingFailures(const BuildQueue *queue);
+
+const char* BuildQueueGetFrontendRerunReason(BuildQueue* queue, MemAllocHeap* heap);

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -290,7 +290,7 @@ void DriverDestroy(Driver *self)
     HeapDestroy(&self->m_Heap);
 }
 
-BuildResult::Enum DriverBuild(Driver *self, int* out_finished_node_count, const char** argv, int argc)
+BuildResult::Enum DriverBuild(Driver *self, int* out_finished_node_count, const char** out_frontend_rerun_reason, const char** argv, int argc)
 {
     const Frozen::Dag *dag = self->m_DagData;
 
@@ -362,6 +362,11 @@ BuildResult::Enum DriverBuild(Driver *self, int* out_finished_node_count, const 
     {
         fclose((FILE *)queue_config.m_FileSigningLog);
         MutexDestroy(&debug_signing_mutex);
+    }
+
+    if (build_result == BuildResult::kRequireFrontendRerun)
+    {
+        *out_frontend_rerun_reason = BuildQueueGetFrontendRerunReason(&build_queue, &self->m_Heap);
     }
 
     *out_finished_node_count = build_queue.m_FinishedNodeCount;

--- a/src/Driver.hpp
+++ b/src/Driver.hpp
@@ -101,7 +101,7 @@ void DriverRemoveStaleOutputs(Driver *self);
 
 void DriverCleanOutputs(Driver *self);
 
-BuildResult::Enum DriverBuild(Driver *self, int* out_finished_node_count, const char** argv, int argc);
+BuildResult::Enum DriverBuild(Driver *self, int* out_finished_node_count, const char** out_frontend_rerun_reason, const char** argv, int argc);
 
 bool DriverInitData(Driver *self);
 

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -430,6 +430,7 @@ int main(int argc, char *argv[])
 
     BuildResult::Enum build_result = BuildResult::kSetupError;
     int finished_node_count = 0;
+    const char* frontend_rerun_reason = "";
 
     if (!DriverInitData(&driver))
         goto leave;
@@ -465,7 +466,7 @@ int main(int argc, char *argv[])
 
     RemoveStaleOutputs(&driver);
 
-    build_result = DriverBuild(&driver, &finished_node_count, (const char**) argv, argc);
+    build_result = DriverBuild(&driver, &finished_node_count, &frontend_rerun_reason, (const char**) argv, argc);
 
     if (!SaveAllBuiltNodes(&driver))
         Log(kError, "Couldn't save AllBuiltNodes");
@@ -530,7 +531,7 @@ leave:
     {
         if (total_time < 60.0)
         {
-            PrintServiceMessage(build_result == 0 ? MessageStatusLevel::Success : MessageStatusLevel::Failure, "*** %s %s (%.2f seconds), %d items updated, %d evaluated", buildTitle, BuildResult::Names[build_result], total_time, g_Stats.m_ExecCount, finished_node_count);
+            PrintServiceMessage(build_result == 0 ? MessageStatusLevel::Success : MessageStatusLevel::Failure, "*** %s %s%s (%.2f seconds), %d items updated, %d evaluated", buildTitle, BuildResult::Names[build_result], frontend_rerun_reason, total_time, g_Stats.m_ExecCount, finished_node_count);
         }
         else
         {
@@ -540,7 +541,7 @@ leave:
             int m = t / 60;
             t -= m * 60;
             int s = t;
-            PrintServiceMessage(build_result == 0 ? MessageStatusLevel::Success : MessageStatusLevel::Failure, "*** %s %s (%.2f seconds - %d:%02d:%02d), %d items updated, %d evaluated", buildTitle, BuildResult::Names[build_result], total_time, h, m, s, g_Stats.m_ExecCount, finished_node_count);
+            PrintServiceMessage(build_result == 0 ? MessageStatusLevel::Success : MessageStatusLevel::Failure, "*** %s %s%s (%.2f seconds - %d:%02d:%02d), %d items updated, %d evaluated", buildTitle, BuildResult::Names[build_result], frontend_rerun_reason, total_time, h, m, s, g_Stats.m_ExecCount, finished_node_count);
         }
     }
 

--- a/src/RunAction.cpp
+++ b/src/RunAction.cpp
@@ -120,7 +120,10 @@ NodeBuildResult::Enum PostRunActionBookkeeping(RuntimeNode* node, ThreadState* t
 
             // Compare digest with the one stored in the signature block
             if (0 != memcmp(&digest, &sig.m_Digest, sizeof digest))
+            {
+                thread_state->m_GlobCausingFrontendRerun = &sig;
                 return false;
+            }
         }
         return true;
     };
@@ -135,7 +138,10 @@ NodeBuildResult::Enum PostRunActionBookkeeping(RuntimeNode* node, ThreadState* t
             FileInfo info = GetFileInfo(path);
 
             if (info.m_Timestamp != timestamp)
+            {
+                thread_state->m_FileCausingFrontendRerun = &sig;
                 return false;
+            }
         }
         return true;
     };


### PR DESCRIPTION
If exiting because a frontend rerun is required by a changing TargetDirectory, report which file/directory it was in the exit message, to help with understanding cases like https://unity.slack.com/archives/C1RM0NBLY/p1610154520001200?thread_ts=1610151219.487000&cid=C1RM0NBLY

The messages look like:

```
[ 7/11      0s] WithDynamicOutput mytargetdir7
[ 8/11      0s] WithDynamicOutput mytargetdir8
[ 9/11      0s] WithDynamicOutput mytargetdir9
*** Tundra requires additional run because timestamp of mytargetdir9 changed (0.95 seconds), 10 items updated, 11 evaluated```
```

and 

```
[ 7/11      0s] WithDynamicOutput mytargetdir7
[ 8/11      0s] WithDynamicOutput mytargetdir8
[ 9/11      0s] WithDynamicOutput mytargetdir9
*** Tundra requires additional run because contents of mytargetdir9 changed (0.77 seconds), 10 items updated, 11 evaluated
```

If multiple things changed that caused the rerun to be necessary, we only report one of them (the last one encountered by the first thread we look at). It will probably make sense at some point in the future to capture _all_ the things causing the rerun somewhere like the structured log.