### PR TITLE
Fix copyfile on Linux

### DIFF
--- a/src/ActionsLinux.cpp
+++ b/src/ActionsLinux.cpp
@@ -128,6 +128,13 @@ ExecResult CopyFiles(const FrozenFileAndHash* src_files, const FrozenFileAndHash
 
             // Verify the link was copied correctly
             char* final_target = ReadSymbolicLink(dst_file, &scratch, nullptr);
+            if (final_target == nullptr)
+            {
+                result.m_ReturnCode = -1;
+                snprintf(tmpBuffer, sizeof(tmpBuffer), "The destination symlink %s could not be read.", dst_file);
+                break;
+            }
+
             if (strcmp(link_target, final_target) != 0)
             {
                 result.m_ReturnCode = -1;

--- a/src/ActionsLinux.cpp
+++ b/src/ActionsLinux.cpp
@@ -132,7 +132,7 @@ ExecResult CopyFiles(const FrozenFileAndHash* src_files, const FrozenFileAndHash
             }
 
             // Ensure that the target file is opened with a writable mode, even if the input file was readonly
-            out_file = open(dst_file, O_WRONLY | O_CREAT | O_TRUNC, src_stat.st_mode | S_IWUSR);
+            out_file = open(dst_file, O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW, (src_stat.st_mode & 0x0fff) | S_IWUSR);
             if (out_file == -1)
             {
                 result.m_ReturnCode = -1;

--- a/src/ActionsLinux.cpp
+++ b/src/ActionsLinux.cpp
@@ -103,6 +103,9 @@ ExecResult CopyFiles(const FrozenFileAndHash* src_files, const FrozenFileAndHash
                 snprintf(tmpBuffer, sizeof(tmpBuffer), "The target path %s already exists and is read-only.", dst_file);
                 break;
             }
+
+            // Always remove the target file first if it existed, to avoid any weirdnesses when opening it for writing
+            unlink(dst_file);
         }
 
         if ((src_stat.st_mode & S_IFMT) == S_IFLNK)
@@ -115,11 +118,6 @@ ExecResult CopyFiles(const FrozenFileAndHash* src_files, const FrozenFileAndHash
                 snprintf(tmpBuffer, sizeof(tmpBuffer), "The source symlink %s could not be read.", src_file);
                 break;
             }
-
-            Log(kDebug, "Source symlink %s read with value \"%s\"", src_file, link_target);
-
-            if (dst_file_info.Exists())
-                unlink(dst_file);
 
             if (symlink(link_target, dst_file) != 0)
             {

--- a/src/ActionsLinux.cpp
+++ b/src/ActionsLinux.cpp
@@ -131,42 +131,12 @@ ExecResult CopyFiles(const FrozenFileAndHash* src_files, const FrozenFileAndHash
                 break;
             }
 
-            struct stat src_stat_before_opening_dst;
-            if (fstat(in_file, &src_stat_before_opening_dst) != 0)
-            {
-                result.m_ReturnCode = -1;
-                snprintf(tmpBuffer, sizeof(tmpBuffer), "Failed to stat source file %s (fd %d) after opening it: %s", src_file, in_file, strerror(errno));
-                break;
-            }
-
-            if (src_stat_before_opening_dst.st_size != src_stat.st_size)
-            {
-                result.m_ReturnCode = -1;
-                snprintf(tmpBuffer, sizeof(tmpBuffer), "Source file %s (fd %d) was originally size %llu, but after opening it, reports a size of %llu.", src_file, in_file, src_stat.st_size, src_stat_before_opening_dst.st_size);
-                break;
-            }
-
             // Ensure that the target file is opened with a writable mode, even if the input file was readonly
             out_file = open(dst_file, O_WRONLY | O_CREAT | O_TRUNC, src_stat.st_mode | S_IWUSR);
             if (out_file == -1)
             {
                 result.m_ReturnCode = -1;
                 snprintf(tmpBuffer, sizeof(tmpBuffer), "The destination file %s could not be opened for writing: %s", dst_file, strerror(errno));
-                break;
-            }
-
-            struct stat src_stat_after_opening_dst;
-            if (fstat(in_file, &src_stat_after_opening_dst) != 0)
-            {
-                result.m_ReturnCode = -1;
-                snprintf(tmpBuffer, sizeof(tmpBuffer), "Failed to stat source file %s (fd %d) after opening destination file: %s", src_file, in_file, strerror(errno));
-                break;
-            }
-
-            if (src_stat_after_opening_dst.st_size != src_stat.st_size)
-            {
-                result.m_ReturnCode = -1;
-                snprintf(tmpBuffer, sizeof(tmpBuffer), "Source file %s (fd %d) was originally size %llu, but after opening the destination file %s (fd %d), it now reports a size of %llu.", src_file, in_file, src_stat.st_size, dst_file, out_file, src_stat_after_opening_dst.st_size);
                 break;
             }
 


### PR DESCRIPTION
Finally appears that I've fixed the weird CopyFile problem I was seeing. I still don't know _exactly_ what the source of the problem was here, but it seems like the most likely explanation is that the destination file already existed and was somehow linked to the source file. It builds the LinuxEditor successfully on Katana now, at least.

To address the problem:
- Unlink the target file before we start copying.
- In the event that somehow the file still exists even after we tried to unlink it: when opening the destination file for writing, refuse to open it if the file exists as a symlink.
- Don't use the stat cache when checking if the destination file already exists. This sidesteps any possible cache invalidation issues.

I also factored out the code for reading the contents of a symlink, and cleaned up some diagnostic code that is no longer needed now that the issue is resolved.