### PR TITLE
Fix build failure messages

### DIFF
--- a/src/BuildQueue.cpp
+++ b/src/BuildQueue.cpp
@@ -20,8 +20,8 @@ const char *Names[Enum::kCount] =
     {
         "build success",
         "build interrupted",
+        "build failed due to an internal error",
         "build failed",
-        "build failed to setup error",
         "requires additional run"};
 }
 

--- a/src/BuildQueue.hpp
+++ b/src/BuildQueue.hpp
@@ -74,6 +74,8 @@ struct ThreadState
 
 namespace BuildResult
 {
+// Note: these need to be kept in sync with the BuildResult::Names defined
+// in the source file.
 enum Enum
 {
     kOk = 0,                   // All nodes built successfully


### PR DESCRIPTION
Commit 9d07e8fd8b522f6bce156a5d002e710515b60f4d rearranged the exit code values, but forgot to update the user-visible status messages.