### PR TITLE
Make sure Unicode paths work on Windows

### DIFF
--- a/src/Actions.cpp
+++ b/src/Actions.cpp
@@ -1,4 +1,5 @@
 #include "Actions.hpp"
+#include "Common.hpp"
 #include <string.h>
 
 // This order should match the order of enum members in Actions.hpp
@@ -42,7 +43,7 @@ ExecResult WriteTextFile(const char* payload, const char* target_file, MemAllocH
 
     memset(&result, 0, sizeof(result));
 
-    FILE* f = fopen(target_file, "wb");
+    FILE* f = OpenFile(target_file, "wb");
     if (!f)
     {
         InitOutputBuffer(&result.m_OutputBuffer, heap);

--- a/src/AllBuiltNodes.cpp
+++ b/src/AllBuiltNodes.cpp
@@ -468,7 +468,7 @@ bool SaveAllBuiltNodes(Driver *self)
     }
     else
     {
-        remove(self->m_DagData->m_StateFileNameTmp);
+        RemoveFileOrDir(self->m_DagData->m_StateFileNameTmp);
     }
 
     HashTableDestroy(&shared_strings);

--- a/src/BinaryWriter.cpp
+++ b/src/BinaryWriter.cpp
@@ -157,7 +157,7 @@ bool BinaryWriterFlush(BinaryWriter *self, const char *out_fn)
 {
     BinaryWriterFinalize(self);
 
-    FILE *f = fopen(out_fn, "wb");
+    FILE *f = OpenFile(out_fn, "wb");
     if (!f)
     {
         int e = errno;

--- a/src/BuildLoop.cpp
+++ b/src/BuildLoop.cpp
@@ -340,7 +340,7 @@ static void AttemptCacheWrite(BuildQueue* queue, ThreadState* thread_state, Runt
 
     char digestString[kDigestStringSize];
     DigestToString(digestString, node->m_CurrentLeafInputSignature->digest);
-    FILE *sig = fopen(digestString, "w");
+    FILE *sig = OpenFile(digestString, "w");
     if (sig == NULL)
     {
         printf("Failed to open file for signature ingredient writing. Skipping CacheWrite.\n");

--- a/src/BuildLoop.cpp
+++ b/src/BuildLoop.cpp
@@ -353,7 +353,7 @@ static void AttemptCacheWrite(BuildQueue* queue, ThreadState* thread_state, Runt
     fclose(sig);
 
     auto writeResult = CacheClient::AttemptWrite(queue->m_Config.m_Dag, node->m_DagNode, node->m_CurrentLeafInputSignature->digest, queue->m_Config.m_StatCache, &queue->m_Lock, thread_state, digestString);
-    remove(digestString);
+    RemoveFileOrDir(digestString);
 
     uint64_t now = TimerGet();
     double duration = TimerDiffSeconds(time_exec_started, now);

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -573,9 +573,9 @@ bool RenameFile(const char *oldf, const char *newf)
 FILE* OpenFile(const char* filename, const char* mode)
 {
 #if defined(TUNDRA_WIN32)
-    FILE* file;
+    FILE* file = nullptr;
     if (_wfopen_s(&file, ToWideString(filename).c_str(), ToWideString(mode).c_str()) != 0)
-        CroakErrno("Unable to open file \"%s\"", filename);
+        PrintErrno();
     return file;
 #else
     return fopen(filename, mode);

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -61,15 +61,6 @@ static void NORETURN FlushAndAbort()
     abort();
 }
 
-FILE* OpenFile(const char* filename, const char* mode)
-{
-#if defined(TUNDRA_WIN32)
-    return _wfopen(ToWideString(filename).c_str(), ToWideString(mode).c_str());
-#else
-    return fopen(filename, mode);
-#endif
-}
-
 void PrintErrno()
 {
 #if TUNDRA_WIN32
@@ -579,4 +570,15 @@ bool RenameFile(const char *oldf, const char *newf)
 #endif
 }
 
+FILE* OpenFile(const char* filename, const char* mode)
+{
+#if defined(TUNDRA_WIN32)
+    FILE* file;
+    if (_wfopen_s(&file, ToWideString(filename).c_str(), ToWideString(mode).c_str()) != 0)
+        CroakErrno("Unable to open file \"%s\"", filename);
+    return file;
+#else
+    return fopen(filename, mode);
+#endif
+}
 

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -61,6 +61,15 @@ static void NORETURN FlushAndAbort()
     abort();
 }
 
+FILE* OpenFile(const char* filename, const char* mode)
+{
+#if defined(TUNDRA_WIN32)
+    return _wfopen(ToWideString(filename).c_str(), ToWideString(mode).c_str());
+#else
+    return fopen(filename, mode);
+#endif
+}
+
 void PrintErrno()
 {
 #if TUNDRA_WIN32
@@ -262,7 +271,7 @@ void SetStructuredLogFileName(const char *path)
 
     if (path != nullptr)
     {
-        s_StructuredLog = fopen(path, "w");
+        s_StructuredLog = OpenFile(path, "w");
         MutexInit(&s_StructuredLogMutex);
     }
 }

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -313,7 +313,7 @@ void GetCwd(char *buffer, size_t buffer_size)
 bool SetCwd(const char *dir)
 {
 #if defined(TUNDRA_WIN32)
-    return TRUE == SetCurrentDirectoryA(dir);
+    return TRUE == SetCurrentDirectoryW(ToWideString(dir).c_str());
 #elif defined(TUNDRA_UNIX)
     return 0 == chdir(dir);
 #else
@@ -563,9 +563,9 @@ bool RemoveFileOrDir(const char *path)
     if (!info.Exists())
         return true;
     else if (info.IsDirectory())
-        return TRUE == RemoveDirectoryA(path);
+        return TRUE == RemoveDirectoryW(ToWideString(path).c_str());
     else
-        return TRUE == DeleteFileA(path);
+        return TRUE == DeleteFileW(ToWideString(path).c_str());
 #endif
 }
 
@@ -575,7 +575,7 @@ bool RenameFile(const char *oldf, const char *newf)
 #if defined(TUNDRA_UNIX)
     return 0 == rename(oldf, newf);
 #else
-    return FALSE != MoveFileExA(oldf, newf, MOVEFILE_REPLACE_EXISTING);
+    return FALSE != MoveFileExW(ToWideString(oldf).c_str(), ToWideString(newf).c_str(), MOVEFILE_REPLACE_EXISTING);
 #endif
 }
 

--- a/src/Common.hpp
+++ b/src/Common.hpp
@@ -53,13 +53,6 @@ bool ConvertToLongPath(std::wstring* path);
 void InitCommon(void);
 
 //-----------------------------------------------------------------------------
-// File handling
-//-----------------------------------------------------------------------------
-
-// Make sure UTF-8 filenames are open and created correctly (specifically on Windows with multibyte character streams)
-FILE* OpenFile(const char* filename, const char* mode);
-
-//-----------------------------------------------------------------------------
 // Error handling
 //-----------------------------------------------------------------------------
 
@@ -143,7 +136,7 @@ inline uint64_t Djb2HashPath64(const char *str) { return Djb2Hash64(str); }
 #endif
 
 //-----------------------------------------------------------------------------
-// Directories
+// Filesystem
 //-----------------------------------------------------------------------------
 
 void GetCwd(char *buffer, size_t buffer_size);
@@ -154,6 +147,9 @@ bool RemoveFileOrDir(const char *path);
 
 // Like rename(), but also works when target file exists on Windows.
 bool RenameFile(const char *oldf, const char *newf);
+
+// Make sure UTF-8 filenames are open and created correctly (specifically on Windows with multibyte character streams)
+FILE* OpenFile(const char* filename, const char* mode);
 
 //-----------------------------------------------------------------------------
 // Misc

--- a/src/Common.hpp
+++ b/src/Common.hpp
@@ -4,6 +4,7 @@
 
 #include <cstddef>
 #include <stdint.h>
+#include <stdio.h>
 
 // Allow the use of alloca() everywhere
 #if defined(_MSC_VER)
@@ -50,6 +51,13 @@ bool ConvertToLongPath(std::wstring* path);
 
 
 void InitCommon(void);
+
+//-----------------------------------------------------------------------------
+// File handling
+//-----------------------------------------------------------------------------
+
+// Make sure UTF-8 filenames are open and created correctly (specifically on Windows with multibyte character streams)
+FILE* OpenFile(const char* filename, const char* mode);
 
 //-----------------------------------------------------------------------------
 // Error handling

--- a/src/DagGenerator.cpp
+++ b/src/DagGenerator.cpp
@@ -1043,7 +1043,7 @@ bool FreezeDagJson(const char* json_filename, const char* dag_fn)
     if (!json_memory)
         Croak("couldn't allocate memory for JSON buffer");
 
-    FILE *f = fopen(json_filename, "rb");
+    FILE *f = OpenFile(json_filename, "rb");
     if (!f)
     {
         Log(kError, "couldn't open %s for reading", json_filename);

--- a/src/DigestCache.cpp
+++ b/src/DigestCache.cpp
@@ -117,7 +117,7 @@ bool DigestCacheSave(DigestCache *self, MemAllocHeap *serialization_heap, const 
     }
     else
     {
-        remove(tmp_filename);
+        RemoveFileOrDir(tmp_filename);
     }
 
     BinaryWriterDestroy(&writer);

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -421,7 +421,7 @@ bool DriverSaveScanCache(Driver *self)
     }
     else
     {
-        remove(self->m_DagData->m_ScanCacheFileNameTmp);
+        RemoveFileOrDir(self->m_DagData->m_ScanCacheFileNameTmp);
     }
 
     return success;

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -333,7 +333,7 @@ BuildResult::Enum DriverBuild(Driver *self, int* out_finished_node_count, char* 
     {
         MutexInit(&debug_signing_mutex);
         queue_config.m_FileSigningLogMutex = &debug_signing_mutex;
-        queue_config.m_FileSigningLog = fopen("signing-debug.txt", "w");
+        queue_config.m_FileSigningLog = OpenFile("signing-debug.txt", "w");
     }
     else
     {

--- a/src/ExecWin32.cpp
+++ b/src/ExecWin32.cpp
@@ -141,7 +141,7 @@ static HANDLE GetOrCreateTempFileFor(int job_id, const char *command_that_just_f
         disp = CREATE_ALWAYS;
         flags = FILE_ATTRIBUTE_TEMPORARY | FILE_FLAG_DELETE_ON_CLOSE;
 
-        result = CreateFileA(temp_dir, access, sharemode, NULL, disp, flags, NULL);
+        result = CreateFileW(ToWideString(temp_dir).c_str(), access, sharemode, NULL, disp, flags, NULL);
 
         if (INVALID_HANDLE_VALUE == result)
         {
@@ -168,7 +168,7 @@ static HANDLE GetOrCreateTempFileFor(int job_id, const char *command_that_just_f
             do
             {
                 Sleep(1000);
-                result = CreateFileA(temp_dir, access, sharemode, NULL, disp, flags, NULL);
+                result = CreateFileW(ToWideString(temp_dir).c_str(), access, sharemode, NULL, disp, flags, NULL);
             } while (result == INVALID_HANDLE_VALUE);
         }
 
@@ -417,7 +417,7 @@ static bool SetupResponseFile(const char *cmd_line, char *out_new_cmd_line, int 
             out_responsefile[response_file_max_length] = '\0';
 
             {
-                HANDLE hf = CreateFileA(out_responsefile, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+                HANDLE hf = CreateFileW(ToWideString(out_responsefile).c_str(), GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
                 if (INVALID_HANDLE_VALUE == hf)
                 {
                     fprintf(stderr, "couldn't create response file %s; @err=%u", out_responsefile, (unsigned int)GetLastError());
@@ -485,7 +485,7 @@ static bool SetupResponseFile(const char *cmd_line, char *out_new_cmd_line, int 
 static void CleanupResponseFile(const char *responseFile)
 {
     if (*responseFile != 0)
-        remove(responseFile);
+        RemoveFileOrDir(responseFile);
 }
 
 static int WaitForFinish(HANDLE processHandle, int (*callback_on_slow)(void *user_data), void *callback_on_slow_userdata, int time_until_first_callback)

--- a/src/FileSign.cpp
+++ b/src/FileSign.cpp
@@ -22,7 +22,7 @@ HashDigest ComputeFileSignatureSha1(StatCache* stat_cache, DigestCache* digest_c
     {
         TimingScope timing_scope(&g_Stats.m_FileDigestCount, &g_Stats.m_FileDigestTimeCycles);
 
-        FILE *f = fopen(filename, "rb");
+        FILE *f = OpenFile(filename, "rb");
         if (!f)
             return result;
 

--- a/src/FileSystem.cpp
+++ b/src/FileSystem.cpp
@@ -39,7 +39,7 @@ uint64_t FileSystemUpdateLastSeenFileSystemTime()
     // To workaround this cache behavior we need to open and close the file for each mtime update.
 
     uint64_t valueToWrite = FileSystem::g_LastSeenFileSystemTime; // not important what we write, just that we write something.
-    FILE* lastSeenFileSystemTimeSampleFileFd = fopen(s_LastSeenFileSystemTimeSampleFile, "w");
+    FILE* lastSeenFileSystemTimeSampleFileFd = OpenFile(s_LastSeenFileSystemTimeSampleFile, "w");
     if (lastSeenFileSystemTimeSampleFileFd == nullptr)
         CroakErrno("Unable to create timestamp file '%s'", lastSeenFileSystemTimeSampleFileFd);
 

--- a/src/LeafInputSignature.cpp
+++ b/src/LeafInputSignature.cpp
@@ -223,7 +223,7 @@ void PrintLeafInputSignature(BuildQueue* buildQueue, const char* outputFile)
     MemAllocLinear scratch;
     LinearAllocInit(&scratch, buildQueue->m_Config.m_Heap, MB(16), "PrintLeafInputSignature");
 
-    FILE *output_signature = fopen(outputFile, "w");
+    FILE *output_signature = OpenFile(outputFile, "w");
     if (output_signature == nullptr)
     {
         Croak("Unable to open %s for writing of signature file\n", outputFile);

--- a/src/LoadOrBuildDag.cpp
+++ b/src/LoadOrBuildDag.cpp
@@ -113,8 +113,8 @@ bool LoadOrBuildDag(Driver *self, const char *dag_fn)
 
     if (!LoadFrozenData<Frozen::Dag>(dag_fn, &self->m_DagFile, &self->m_DagData))
     {
-        remove(dag_fn);
-        remove(dagderived_filename);
+        RemoveFileOrDir(dag_fn);
+        RemoveFileOrDir(dagderived_filename);
         return ExitRequestingFrontendRun("%s couldn't be loaded", dag_fn);
     }
 
@@ -139,8 +139,8 @@ bool LoadOrBuildDag(Driver *self, const char *dag_fn)
 
     if (!LoadFrozenData<Frozen::DagDerived>(dagderived_filename, &self->m_DagDerivedFile, &self->m_DagDerivedData))
     {
-        remove(dag_fn);
-        remove(dagderived_filename);
+        RemoveFileOrDir(dag_fn);
+        RemoveFileOrDir(dagderived_filename);
         return ExitRequestingFrontendRun("%s couldn't be loaded", dag_fn);
     }
 
@@ -170,9 +170,9 @@ bool LoadOrBuildDag(Driver *self, const char *dag_fn)
     MmapFileUnmap(&self->m_DagDerivedFile);
     self->m_DagDerivedData = nullptr;
 
-    if (remove(dag_fn))
+    if (!RemoveFileOrDir(dag_fn))
         Croak("Failed to remove out of date dag at %s", dag_fn);
-    if (remove(dagderived_filename))
+    if (!RemoveFileOrDir(dagderived_filename))
         Croak("Failed to remove out of date dagderived file at %s", dagderived_filename);
 
     ExitRequestingFrontendRun("%s no longer valid. %s", FindFileNameInside(dag_fn), out_of_date_reason);

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -239,7 +239,12 @@ static void ShowHelp()
     }
 }
 
+#if defined(TUNDRA_WIN32)
+// On Windows we want to parse the command line using wide characters for Unicode support
+int real_main(int argc, char* argv[])
+#else
 int main(int argc, char *argv[])
+#endif
 {
 
 
@@ -556,3 +561,25 @@ leave:
 
     return build_result;
 }
+
+#if defined(TUNDRA_WIN32)
+// On Windows we want to parse the command line using wide characters for Unicode support
+int wmain(int argc, wchar_t* argv[], wchar_t* envp[])
+{
+    char** argv_mbcs = new char* [argc];
+    for (int i = 0; i < argc; i++)
+    {
+        std::string argv_mbcs_str = ToMultiByteUTF8String(argv[i]);
+        argv_mbcs[i] = new char[strlen(argv_mbcs_str.c_str()) + 1];
+        strcpy(argv_mbcs[i], argv_mbcs_str.c_str());
+    }
+
+    int res = real_main(argc, argv_mbcs);
+
+    for (int i = 0; i < argc; i++)
+        delete[] argv_mbcs[i];
+    delete[] argv_mbcs;
+
+    return res;
+}
+#endif

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -566,18 +566,17 @@ leave:
 // On Windows we want to parse the command line using wide characters for Unicode support
 int wmain(int argc, wchar_t* argv[], wchar_t* envp[])
 {
+    std::string* argv_mbcs_str = new std::string [argc];
     char** argv_mbcs = new char* [argc];
     for (int i = 0; i < argc; i++)
     {
-        std::string argv_mbcs_str = ToMultiByteUTF8String(argv[i]);
-        argv_mbcs[i] = new char[strlen(argv_mbcs_str.c_str()) + 1];
-        strcpy(argv_mbcs[i], argv_mbcs_str.c_str());
+        argv_mbcs_str[i] = ToMultiByteUTF8String(argv[i]);
+        argv_mbcs[i] = const_cast<char*>(argv_mbcs_str[i].c_str());
     }
 
     int res = real_main(argc, argv_mbcs);
 
-    for (int i = 0; i < argc; i++)
-        delete[] argv_mbcs[i];
+    delete[] argv_mbcs_str;
     delete[] argv_mbcs;
 
     return res;

--- a/src/MemoryMappedFile.cpp
+++ b/src/MemoryMappedFile.cpp
@@ -99,7 +99,7 @@ void MmapFileMap(MemoryMappedFile *self, const char *fn)
     const DWORD creation_disposition = OPEN_EXISTING;
     const DWORD flags = FILE_ATTRIBUTE_NORMAL;
 
-    HANDLE file = CreateFileA(fn, desired_access, share_mode, NULL, creation_disposition, flags, NULL);
+    HANDLE file = CreateFileW(ToWideString(fn).c_str(), desired_access, share_mode, NULL, creation_disposition, flags, NULL);
 
     if (INVALID_HANDLE_VALUE == file)
     {

--- a/src/NodeResultPrinting.cpp
+++ b/src/NodeResultPrinting.cpp
@@ -363,7 +363,7 @@ static void PrintNodeResult(const NodeResultPrintData *data, BuildQueue *queue)
             snprintf(titleBuffer, sizeof titleBuffer, "Contents of %s", file);
 
             char *content_buffer;
-            FILE *f = fopen(file, "rb");
+            FILE *f = OpenFile(file, "rb");
             if (!f)
             {
 

--- a/src/Profiler.cpp
+++ b/src/Profiler.cpp
@@ -96,7 +96,7 @@ static void EscapeString(const char *src, char *dst, int dstSpace)
 
 void ProfilerWriteOutput()
 {
-    FILE *f = fopen(s_ProfilerState.m_FileName, "w");
+    FILE *f = OpenFile(s_ProfilerState.m_FileName, "w");
     if (!f)
     {
         Log(kWarning, "profiler: failed to write profiler output file into '%s'", s_ProfilerState.m_FileName);

--- a/src/RemoveStaleOutputs.cpp
+++ b/src/RemoveStaleOutputs.cpp
@@ -15,14 +15,7 @@ static bool CleanupPath(const char *path)
         return false;
     if (info.IsSymlink())
         return false;
-#if defined(TUNDRA_UNIX)
-    return 0 == remove(path);
-#else
-    else if (info.IsDirectory())
-        return TRUE == RemoveDirectoryA(path);
-    else
-        return TRUE == DeleteFileA(path);
-#endif
+    return RemoveFileOrDir(path);
 }
 
 void RemoveStaleOutputs(Driver *self)

--- a/src/ReportIncludes.cpp
+++ b/src/ReportIncludes.cpp
@@ -119,7 +119,7 @@ bool ReportIncludes(Driver *self)
     JsonWriteEndObject(&msg);
 
     // Write into file.
-    FILE *f = fopen(self->m_Options.m_IncludesOutput, "w");
+    FILE *f = OpenFile(self->m_Options.m_IncludesOutput, "w");
     if (!f)
     {
         Log(kError, "Failed to create includes report file '%s'", self->m_Options.m_IncludesOutput);

--- a/src/RunAction.cpp
+++ b/src/RunAction.cpp
@@ -181,7 +181,7 @@ NodeBuildResult::Enum RunAction(BuildQueue *queue, ThreadState *thread_state, Ru
         for (const FrozenFileAndHash &output : node_data->m_OutputFiles)
         {
             Log(kDebug, "Removing output file %s before running action", output.m_Filename.Get());
-            remove(output.m_Filename);
+            RemoveFileOrDir(output.m_Filename);
             StatCacheMarkDirty(stat_cache, output.m_Filename, output.m_FilenameHash);
         }
 
@@ -307,7 +307,7 @@ NodeBuildResult::Enum RunAction(BuildQueue *queue, ThreadState *thread_state, Ru
         for (const FrozenFileAndHash &output : node_data->m_OutputFiles)
         {
             Log(kDebug, "Removing output file %s from failed action \"%s\" (return code %d)", output.m_Filename.Get(), node->m_DagNode->m_Annotation.Get(), result.m_ReturnCode);
-            remove(output.m_Filename);
+            RemoveFileOrDir(output.m_Filename);
             StatCacheMarkDirty(stat_cache, output.m_Filename, output.m_FilenameHash);
         }
     }

--- a/src/Scanner.cpp
+++ b/src/Scanner.cpp
@@ -195,7 +195,7 @@ bool ScanImplicitDeps(StatCache *stat_cache, const ScanInput *input, ScanOutput 
             BufferClear(&found_includes);
 
             // Read file into RAM, and add a terminating newline character.
-            FILE *f = fopen(fn, "rb");
+            FILE *f = OpenFile(fn, "rb");
             if (!f)
                 continue;
 


### PR DESCRIPTION
This PR changes usages of file handling on Windows to account for Unicode filenames.

Calls to `fopen()` were changed to `OpenFile()`, a new wrapper for calling either `_wfopen()` on Windows or `fopen()` on other systems.

Calls to `remove()` were changed to `RemoveFileOrDir()`, a pre-existing wrapper for calling either `RemoveDirectoryW()`/`DeleteFileW()` on Windows or `remove()` on other platforms. Note that `remove()` returns 0 on success, so any checks of the return value for calls to `remove()` needed to be inverted.

Usages of Windows ANSI API functions were changes to wide character versions (`<name>A()` calls changed to `<name>W()` calls, such as `RemoveDirectoryA()` -> `RemoveDirectoryW()`).

The already existing helper function `ToWideString()` is used to translate multi-byte character strings into wide characters, using code page `CP_UTF8`. I believe this is a robust solution, no matter what a user system's language configuration, but I'd like to confirm that. I think perhaps we would need to make sure Bee's console output is always UTF-8 in this case?

`wmain()` was added to `src/Main.cpp` and surrounded by an #ifdef for Windows, along with renaming `main()`. When compiling for Windows, `main()` will be named `real_main()`, and `wmain()` will be the entry point, passing in command line args as `wchar_t* argv[]`. We then convert them to multi-byte UTF-8 character strings and pass them to `real_main()` as `char* argv[]`.