### PR TITLE
Improve performance of scoring algorithm + write more stats

### DIFF
--- a/Build.bee.cs
+++ b/Build.bee.cs
@@ -123,6 +123,7 @@ class Build
         tundraLibraryProgram.CompilerSettingsForMsvc().Add(compiler => compiler.WithUnicode(false));
         tundraLibraryProgram.Sources.Add(SourceFolder.Files("*.c*").Where(f => !f.FileName.EndsWith("Main.cpp"))
             .ToArray());
+        tundraLibraryProgram.Defines.Add("__STDC_FORMAT_MACROS");
         tundraLibraryProgram.PublicIncludeDirectories.Add(SourceFolder);
         tundraLibraryProgram.Libraries.Add(IsWindows,
             new SystemLibrary("Rstrtmgr.lib"),

--- a/src/DagDerivedCompiler.cpp
+++ b/src/DagDerivedCompiler.cpp
@@ -255,7 +255,7 @@ struct CompileDagDerivedWorker
              toUseEdges += dag->m_DagNodes[i].m_ToUseDependencies.GetCount();
         }
 
-        printf("Baked DAG. NodeCount=%d, TotalFlattenedEdges=%" PRId64 " ToBuildEdges=%" PRId64 " ToUseEdges=%" PRId64 " MaxPoints=%d\n", node_count, totalFlattenedEdges, toBuildEdges, toUseEdges, this->max_points);
+        printf("Finished compiling graph: %d nodes, %" PRId64 " flattened edges (%" PRId64 " ToBuild, %" PRId64 " ToUse), maximum node priority %d\n", node_count, totalFlattenedEdges, toBuildEdges, toUseEdges, this->max_points);
     }
 
     bool WriteStreams(const char* dagderived_filename)

--- a/src/DagDerivedCompiler.cpp
+++ b/src/DagDerivedCompiler.cpp
@@ -351,6 +351,8 @@ struct CompileDagDerivedWorker
                     if (previouslyCalculated != -1)
                         return previouslyCalculated;
 
+                    all_scores[nodeindex] = 0;
+
                     int highestCostOfAnyBacklink = 0;
                     for (auto backlink: backlinksBuffers[nodeindex])
                         highestCostOfAnyBacklink = std::max(highestCostOfAnyBacklink, calculateCumulativePoints(backlink));

--- a/src/DagDerivedCompiler.cpp
+++ b/src/DagDerivedCompiler.cpp
@@ -273,17 +273,17 @@ struct CompileDagDerivedWorker
         }
 
         backlinksBuffers = HeapAllocateArrayZeroed<Buffer<int32_t>>(heap, node_count);
-            for (int32_t i = 0; i < node_count; ++i)
-            {
-                for(int dep : combinedDependenciesBuffers[i])
-                    BufferAppendOneIfNotPresent(&backlinksBuffers[dep], heap, i);
-            }
+        for (int32_t i = 0; i < node_count; ++i)
+        {
+            for(int dep : combinedDependenciesBuffers[i])
+                BufferAppendOneIfNotPresent(&backlinksBuffers[dep], heap, i);
+        }
 
         auto WriteArrayOfIndices = [=](BinarySegment* segment, Buffer<int32_t>& indices)->void{
-                BinarySegmentWriteInt32(segment, indices.m_Size);
-                BinarySegmentWritePointer(segment, BinarySegmentPosition(arraydata_seg));
-                for(int32_t dep : indices)
-                    BinarySegmentWriteInt32(arraydata_seg, dep);
+            BinarySegmentWriteInt32(segment, indices.m_Size);
+            BinarySegmentWritePointer(segment, BinarySegmentPosition(arraydata_seg));
+            for(int32_t dep : indices)
+                BinarySegmentWriteInt32(arraydata_seg, dep);
         };
 
         BinarySegmentWriteUint32(main_seg, Frozen::DagDerived::MagicNumber);

--- a/src/DagGenerator.cpp
+++ b/src/DagGenerator.cpp
@@ -14,6 +14,7 @@
 #include "LeafInputSignature.hpp"
 #include "FileInfoHelper.hpp"
 #include "Actions.hpp"
+#include <Stats.hpp>
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -999,6 +1000,8 @@ static bool CreateDagFromJsonData(char *json_memory, const char *dag_fn)
                 Log(kInfo, "Nothing to do");
                 exit(BuildResult::kOk);
             }
+
+            TimingScope timing_scope(nullptr, &g_Stats.m_CompileDagTime);
 
             BinaryWriter writer;
             BinaryWriterInit(&writer, &heap);

--- a/src/Inspect.cpp
+++ b/src/Inspect.cpp
@@ -143,6 +143,24 @@ static void DumpDag(const Frozen::Dag *data)
             printf("    %s = %s\n", env.m_Name.Get(), env.m_Value.Get());
         }
 
+        printf("  globsignature:\n");
+        for (const auto& globSig : node.m_GlobSignatures)
+        {
+            char digest_str[kDigestStringSize];
+            DigestToString(digest_str, globSig.m_Digest);
+            printf("    %s = %s\n", globSig.m_Path.Get(), digest_str);
+        }
+        printf("  statsignature:\n");
+        for (const auto& statSig : node.m_StatSignatures)
+        {
+            printf("    %s = %d\n", statSig.m_Path.Get(), statSig.m_StatResult);
+        }
+        printf("  filesignature:\n");
+        for (const auto& fileSig : node.m_FileSignatures)
+        {
+            printf("    %s = %lld\n", fileSig.m_Path.Get(),  fileSig.m_Timestamp);
+        }
+
         printf("  scannerIndex: %d\n", node.m_ScannerIndex);
         if (node.m_ScannerIndex != -1)
         {

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -520,6 +520,11 @@ leave:
         printf("  munmap() time:   %10.2f ms\n", TimerToSeconds(g_Stats.m_MunmapTimeCycles) * 1000.0);
         printf("  stat() calls:    %10u\n", g_Stats.m_StatCount);
         printf("  stat() time:     %10.2f ms\n", TimerToSeconds(g_Stats.m_StatTimeCycles) * 1000.0);
+
+        printf("compiledag:        %10.2f ms\n", TimerToSeconds(g_Stats.m_CompileDagTime) * 1000.0);
+        printf("compilederived     %10.2f ms\n", TimerToSeconds(g_Stats.m_CompileDagDerivedTime) * 1000.0);
+        printf("  cumulativepoints %10.2f ms\n", TimerToSeconds(g_Stats.m_CumulativePointsTime) * 1000.0);
+        printf("  nongenindices    %10.2f ms\n", TimerToSeconds(g_Stats.m_CalculateNonGeneratedIndicesTime) * 1000.0);
     }
 
     double total_time = TimerDiffSeconds(start_time, TimerGet());

--- a/src/Stats.hpp
+++ b/src/Stats.hpp
@@ -43,6 +43,11 @@ struct TundraStats
     uint32_t m_DigestCacheHits;
     uint32_t m_FileDigestCount;
     uint64_t m_FileDigestTimeCycles;
+
+    uint64_t m_CompileDagTime;
+    uint64_t m_CompileDagDerivedTime;
+    uint64_t m_CalculateNonGeneratedIndicesTime;
+    uint64_t m_CumulativePointsTime;
 };
 
 struct TimingScope


### PR DESCRIPTION
Implement a simpler priority scoring mechanism for nodes that has less draconion algorithmic complexity.
Print out more stats related to dag baking to help profiling, as well as casual observing important stats about the dag.