### PR TITLE
Timestamp precision

### DIFF
--- a/src/BuildLoop.cpp
+++ b/src/BuildLoop.cpp
@@ -479,6 +479,7 @@ static NodeBuildResult::Enum ExecuteNode(BuildQueue* queue, RuntimeNode* node, M
         auto fileSystemTimeNow = FileSystemUpdateLastSeenFileSystemTime();
         if (latestTimestampSeenForNonGeneratedInputFile == fileSystemTimeNow)
         {
+            ProfilerScope prof_scope("FileSystemWaitUntilFileModificationDateIsInThePast", thread_state->m_ProfilerThreadId, nonGeneratedInputFileWithTimestamp);
             // If the latest modification time of any non generated input file matches now, then we wait for the next file system mtime tick.
             // The reason we do this is so we can safely detect changes done by the user either during graph execution or in between
             // two tundra executions happening within the same file system mtime frame.

--- a/src/FileInfo.cpp
+++ b/src/FileInfo.cpp
@@ -92,7 +92,12 @@ FileInfo GetFileInfo(const char *path)
 
     result.m_Flags = flags;
     // Do not allow directories to expose real timestamps, as it's not reliable behaviour across platforms
-    result.m_Timestamp = (flags & FileInfo::kFlagDirectory) ? kDirectoryTimestamp : stbuf.st_mtimespec.tv_sec * 1000000000 + stbuf.st_mtimespec.tv_nsec;
+    result.m_Timestamp = (flags & FileInfo::kFlagDirectory) ? kDirectoryTimestamp : 
+#if defined(TUNDRA_APPLE)
+        stbuf.st_mtimespec.tv_sec * 1000000000 + stbuf.st_mtimespec.tv_nsec;
+#else
+        stbuf.st_mtime * 1000000000 + stbuf.st_mtime_nsec;
+#endif       
     result.m_Size = stbuf.st_size;
 
     return result;

--- a/src/FileInfo.cpp
+++ b/src/FileInfo.cpp
@@ -93,10 +93,12 @@ FileInfo GetFileInfo(const char *path)
     result.m_Flags = flags;
     // Do not allow directories to expose real timestamps, as it's not reliable behaviour across platforms
     result.m_Timestamp = (flags & FileInfo::kFlagDirectory) ? kDirectoryTimestamp : 
-#if defined(TUNDRA_APPLE)
+#if !defined(_POSIX_C_SOURCE) || defined(_DARWIN_C_SOURCE)
         stbuf.st_mtimespec.tv_sec * 1000000000 + stbuf.st_mtimespec.tv_nsec;
+#elif defined __USE_MISC || defined __USE_XOPEN2K8
+        stbuf.st_mtim.tv_sec * 1000000000 + stbuf.st_mtim.tv_nsec;
 #else
-        stbuf.st_mtime * 1000000000 + stbuf.st_mtime_nsec;
+        stbuf.st_mtime * 1000000000 + stbuf.st_mtimensec;        
 #endif       
     result.m_Size = stbuf.st_size;
 

--- a/src/FileInfo.cpp
+++ b/src/FileInfo.cpp
@@ -92,7 +92,7 @@ FileInfo GetFileInfo(const char *path)
 
     result.m_Flags = flags;
     // Do not allow directories to expose real timestamps, as it's not reliable behaviour across platforms
-    result.m_Timestamp = (flags & FileInfo::kFlagDirectory) ? kDirectoryTimestamp : stbuf.st_mtime;
+    result.m_Timestamp = (flags & FileInfo::kFlagDirectory) ? kDirectoryTimestamp : stbuf.st_mtimespec.tv_sec * 1000000000 + stbuf.st_mtimespec.tv_nsec;
     result.m_Size = stbuf.st_size;
 
     return result;


### PR DESCRIPTION
It turns out that limiting file timestamps to 1 second precision can cause noticeable delays in build time.

To ensure correctness of build results, tundra will wait until time stamps to input files are all in the past - so it can detect changes to files between very fast runs. If file system precision is 1s, this can cause delays of up to 1 seconds, which cause noticeable slowdowns in incremental player builds.

This PR changes file system timestamps to be measured in nanoseconds, if the `stat` function on the host OS supports it - this is the case on macos and linux. On windows, we can also get higher precision timestamps, but not using the `stat` function - we'd have to use win32 APIs for that (`GetFileInformationByHandle`/`GetFileInformationByHandleEx`). We would need to verify that these APIs are not slower than using `stat`.

This PR also adds a profiler marker whenever we need to add a delay to wait for a file's timestamp to be in the past.

Because timestamps are now in ns precision, this means that previous timestamps are no longer valid - this tundra update will cause a rebuild of everything. Also this PR assumes that tundra only uses timestamps for comparison, and does not have any hardcoded assumptions on what the values in timestamps mean. If you think this may be wrong, let me know!