### PR TITLE
windows high-precision timestamp

### DIFF
--- a/src/FileInfo.cpp
+++ b/src/FileInfo.cpp
@@ -42,39 +42,14 @@ FileInfo GetFileInfo(const char *path)
     TimingScope timing_scope(&g_Stats.m_StatCount, &g_Stats.m_StatTimeCycles);
 
     FileInfo result;
-#if defined(TUNDRA_UNIX)
-    struct stat stbuf;
-#elif defined(TUNDRA_WIN32)
-    struct __stat64 stbuf;
-#endif
 
     uint32_t flags = 0;
 
 #if defined(TUNDRA_UNIX)
+    struct stat stbuf;
 
     if (0 != lstat(path, &stbuf))
         goto Failure;
-
-#elif defined(TUNDRA_WIN32)
-
-    DWORD attrs;
-
-    std::wstring widePath(ToWideString(path));
-    //// To work around maximum path length limitations on Windows, we have to use the wide-character version of the API, with a special prefix
-    if (!ConvertToLongPath(&widePath))
-        goto Failure;
-
-    if (0 != _wstat64(widePath.c_str(), &stbuf))
-        goto Failure;
-
-    attrs = GetFileAttributesW(widePath.c_str());
-    if (attrs == INVALID_FILE_ATTRIBUTES)
-        goto Failure;
-  
-
-    if ((attrs & FILE_ATTRIBUTE_REPARSE_POINT) != 0)
-        flags |= FileInfo::kFlagSymlink;
-#endif
 
     flags |= FileInfo::kFlagExists;
 
@@ -90,8 +65,6 @@ FileInfo GetFileInfo(const char *path)
     if ((stbuf.st_mode & S_IWRITE) == 0)
       flags |= FileInfo::kFlagReadOnly;
 
-    result.m_Flags = flags;
-
     // Do not allow directories to expose real timestamps, as it's not reliable behaviour across platforms
     result.m_Timestamp = (flags & FileInfo::kFlagDirectory) ? kDirectoryTimestamp : 
     // high-precision timestaps in stat struct is not standardized. Different system headers 
@@ -105,6 +78,55 @@ FileInfo GetFileInfo(const char *path)
 #endif       
 
     result.m_Size = stbuf.st_size;
+
+#elif defined(TUNDRA_WIN32)
+
+    std::wstring widePath(ToWideString(path));
+    //// To work around maximum path length limitations on Windows, we have to use the wide-character version of the API, with a special prefix
+    if (!ConvertToLongPath(&widePath))
+        goto Failure;
+
+    HANDLE hFile = CreateFileW(widePath.c_str(),
+                            GENERIC_READ,
+                            FILE_SHARE_READ |
+                            FILE_SHARE_WRITE | 
+                            FILE_SHARE_DELETE,
+                            NULL,
+                            OPEN_EXISTING,
+                            FILE_FLAG_BACKUP_SEMANTICS,
+                            NULL);
+
+    if (hFile == INVALID_HANDLE_VALUE)
+        goto Failure;
+
+    BY_HANDLE_FILE_INFORMATION info;
+    if (!GetFileInformationByHandle(hFile, &info))
+    {
+        CloseHandle(hFile);
+        goto Failure;
+    }
+
+    flags |= FileInfo::kFlagExists;
+
+    if ((info.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0)
+        flags |= FileInfo::kFlagSymlink;
+    else if ((info.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0)
+        flags |= FileInfo::kFlagDirectory;
+    else
+        flags |= FileInfo::kFlagFile;
+
+    if ((info.dwFileAttributes & FILE_ATTRIBUTE_READONLY) != 0)
+        flags |= FileInfo::kFlagReadOnly;
+
+    result.m_Timestamp = (flags & FileInfo::kFlagDirectory) 
+        ? kDirectoryTimestamp 
+        : ((((uint64_t)info.ftLastWriteTime.dwHighDateTime) << 32) + info.ftLastWriteTime.dwLowDateTime);
+
+    result.m_Size = (((uint64_t)info.nFileSizeHigh) << 32) + info.nFileSizeLow;
+
+    CloseHandle(hFile);
+#endif
+    result.m_Flags = flags;
 
     return result;
 


### PR DESCRIPTION
Windows version of #124 .

This basically rewrites the  `GetFileInfo` function for windows to get all information using the Win32 `GetFileInformationByHandle` API, instead of a combination of `_wstat64` and `GetFileAttributesW`. Unlike `_wstat64`,  `GetFileInformationByHandle` will return timestamps with 100ns precision.

Timestamps are not set up to match timestamps on mac and unix in units and timeline. I assume that this does not matter because timestamps are only used to compare with each other?

Tested in Bee here:
https://github.cds.internal.unity3d.com/unity/bee/pull/35