### PR TITLE
bump magic number

### DIFF
--- a/src/AllBuiltNodes.hpp
+++ b/src/AllBuiltNodes.hpp
@@ -44,7 +44,7 @@ struct BuiltNode
 
 struct AllBuiltNodes
 {
-    static const uint32_t MagicNumber = 0x53533dc2 ^ kTundraHashMagic;
+    static const uint32_t MagicNumber = 0x53533dc3 ^ kTundraHashMagic;
 
     uint32_t m_MagicNumber;
 


### PR DESCRIPTION
By no longer supplying an action field for copy or writetextfile actions the build state file from newer tundra versions is no longer compatible with older tundras (as shipped in Unity 21.1), causing crashes when trying to determine if nodes need to rebuild in an old tundra. Changing the magic number makes older tundra ignore these files, fixing this issue.